### PR TITLE
ノーマライズハンドラでtrim後の値が空文字列となった場合、nullに変換する処理を追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.3.0'
+version = '1.4.0'
 description = '画面オンライン処理方式を実現する。'
 
 buildscript {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Mon Nov 21 15:09:59 JST 2016
+#Thu Jul 07 09:48:24 JST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/nablarch/fw/web/handler/normalizer/TrimNormalizer.java
+++ b/src/main/java/nablarch/fw/web/handler/normalizer/TrimNormalizer.java
@@ -1,7 +1,11 @@
 package nablarch.fw.web.handler.normalizer;
 
+import nablarch.core.util.StringUtil;
+
 /**
  * 前後のホワイトスペース({@link Character#isWhitespace(int)})を除去するノーマライザ実装クラス。
+ * 
+ * ホワイトスペースを除去した結果、空文字列となった場合には{@code null}に置き換える。
  *
  * @author Hisaaki Shioiri
  */
@@ -51,6 +55,7 @@ public class TrimNormalizer implements Normalizer {
                 break;
             }
         }
-        return value.substring(start, end);
+        final String trimmed = value.substring(start, end);
+        return StringUtil.isNullOrEmpty(trimmed) ? null : trimmed;
     }
 }

--- a/src/test/java/nablarch/common/web/validator/BeanValidationStrategyTest.java
+++ b/src/test/java/nablarch/common/web/validator/BeanValidationStrategyTest.java
@@ -30,6 +30,7 @@ import org.hamcrest.collection.IsIterableWithSize;
 import nablarch.common.web.interceptor.InjectForm;
 import nablarch.common.web.validator.bean.SampleBean;
 import nablarch.common.web.validator.bean.UserForm;
+import nablarch.common.web.validator.bean.WithArrayBean;
 import nablarch.core.ThreadContext;
 import nablarch.core.message.ApplicationException;
 import nablarch.core.message.Message;
@@ -42,6 +43,7 @@ import nablarch.fw.web.HttpMethodBinding;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
 import nablarch.fw.web.MockHttpRequest;
+import nablarch.fw.web.handler.NormalizationHandler;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import nablarch.test.support.SystemRepositoryResource;
 
@@ -379,6 +381,29 @@ public class BeanValidationStrategyTest {
                     MessageMatcher.is("項目間のバリデーションエラー", "form.sub.multiItemValidation")
             ));
         }
+    }
+
+    /**
+     * 配列項目のコピーテスト
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testArrayItem() throws Exception {
+        Object action = new Object() {
+            @InjectForm(form = WithArrayBean.class, prefix = "form")
+            public HttpResponse getIndexHtml(HttpRequest req, ExecutionContext ctx) {
+                WithArrayBean bean = ctx.getRequestScopedVar("form");
+                assertThat(bean.getId(), is("100"));
+                assertThat(bean.getNumbers(), is(new String[] {"1", null, "3"}));
+                return new HttpResponse();
+            }
+        };
+        context.addHandler(new NormalizationHandler());
+        context.addHandler("//", new HttpMethodBinding(action));
+        context.handleNext(new MockHttpRequest("GET /index.html HTTP/1.1")
+                .setParam("form.id", "100")
+                .setParam("form.numbers", "1", "    ", "3"));
     }
 
     private static class MessageMatcher extends TypeSafeMatcher<Message> {

--- a/src/test/java/nablarch/common/web/validator/bean/WithArrayBean.java
+++ b/src/test/java/nablarch/common/web/validator/bean/WithArrayBean.java
@@ -1,0 +1,26 @@
+package nablarch.common.web.validator.bean;
+
+import java.io.Serializable;
+
+public class WithArrayBean implements Serializable {
+
+    private String id;
+
+    private String[] numbers;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    public String[] getNumbers() {
+        return numbers;
+    }
+
+    public void setNumbers(final String[] numbers) {
+        this.numbers = numbers;
+    }
+}

--- a/src/test/java/nablarch/fw/web/handler/NormalizationHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/NormalizationHandlerTest.java
@@ -1,5 +1,6 @@
 package nablarch.fw.web.handler;
 
+import static nablarch.fw.web.handler.HttpAccessLogFormatter.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -23,7 +24,7 @@ public class NormalizationHandlerTest {
     private final NormalizationHandler sut = new NormalizationHandler();
 
     /**
-     * デフォルト構成の場合、{@link nablarch.fw.web.handler.normalizer.TrimNormalizer}により、ノーマライズ処理が実行されること。
+     * デフォルト構成の場合、{@link TrimNormalizer}により、ノーマライズ処理が実行されること。
      *
      * @throws Exception
      */
@@ -39,6 +40,7 @@ public class NormalizationHandlerTest {
         });
         final MockHttpRequest request = new MockHttpRequest();
         request.setParam("spaceonly", " \t\r\n　");
+        request.setParam("someEmpty", "1", "  ", "3", "　　");
         request.setParam("trim1", " value ");
         request.setParam("trim2", "\t 　\r\naa\uD867\uDE3Dbb\t\r\n \t");         // サロゲートペア
         request.setParam("key", "v a l");
@@ -46,7 +48,8 @@ public class NormalizationHandlerTest {
 
         sut.handle(request, context);
 
-        assertThat("空文字列になること", request.getParam("spaceonly"), is(toArray("")));
+        assertThat("nullになること", request.getParam("spaceonly"), is(new String[] {null}));
+        assertThat("空文字列になった要素だけnullに置き換えれること", request.getParam("someEmpty"),is(toArray("1", null, "3", null)));
         assertThat("前後のスペースがトリムされること", request.getParam("trim1"), is(toArray("value")));
         assertThat("サロゲートペアがあっても問題なくトリムできること", request.getParam("trim2"), is(toArray("aa\uD867\uDE3Dbb")));
 


### PR DESCRIPTION
ノーマライズハンドラでtrim後の値が空文字列となった場合、nullに変換する処理を追加

NAB-6 フレームワークでの空文字とnullの扱いを明確にする