### PR TITLE
CopyOnReadMapで持っているThreadLocal変数を確実にremoveするように変更。

### DIFF
--- a/src/main/java/nablarch/fw/web/handler/SessionConcurrentAccessHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/SessionConcurrentAccessHandler.java
@@ -146,6 +146,10 @@ public class SessionConcurrentAccessHandler implements Handler<Object, Object> {
                 }
                 LockableMap<String, Object>
                         lockable = wrappedSession.getDelegateMapOfType(LockableMap.class);
+                
+                // CopyOnReadMapが保持するThreadLocalを明示的に削除する
+                wrappedSession.getDelegateMapOfType(CopyOnReadMap.class)
+                              .refresh();
 
                 // ここで同期アクセス制御を終了させる。
                 if (lockable != null) {


### PR DESCRIPTION
CopyOnReadMapで持っているThreadLocal変数を確実にremoveするように変更。

NAB-7 ThreadLocalがクリアされていない