### PR TITLE
boundaryの抽出方法を変更

### DIFF
--- a/src/main/java/nablarch/fw/web/upload/MultipartParser.java
+++ b/src/main/java/nablarch/fw/web/upload/MultipartParser.java
@@ -143,6 +143,10 @@ class MultipartParser {
         if (boundary.startsWith("\"")) {
             boundary = boundary.replace('"', ' ').trim();
         }
+        if (boundary.contains(";")) {
+            final int pos = boundary.indexOf(';');
+            boundary = boundary.substring(0, pos);
+        }
         return "--" + boundary;
     }
 

--- a/src/test/java/nablarch/fw/web/upload/MultipartParserTest.java
+++ b/src/test/java/nablarch/fw/web/upload/MultipartParserTest.java
@@ -76,7 +76,7 @@ public class MultipartParserTest {
     public void testParse() throws IOException {
         MockServletInputStream in = new MockServletInputStream(
                 getClass().getResourceAsStream("req.dat"));
-        String contentType = "multipart/form-data; boundary=---------------------------2394118477469";
+        String contentType = "multipart/form-data; boundary=---------------------------2394118477469; charset=utf-8";
         int contentLength = 338;
 
         MultipartContext ctx = new MultipartContext(contentType, contentLength, "UTF-8");


### PR DESCRIPTION
boundaryの後ろにcharsetなどがついている場合でも、boundaryのみを抽出出来るように変更

NAB-167