### PR TITLE
リダイレクトでスキーム指定できるようにする

### DIFF
--- a/src/main/java/nablarch/fw/web/ResourceLocator.java
+++ b/src/main/java/nablarch/fw/web/ResourceLocator.java
@@ -77,10 +77,12 @@ import nablarch.core.util.annotation.Published;
  *     (書式)
  *         redirect://(リダイレクト先パス)
  *         http(s)://(リダイレクト先URL)
+ *         redirect:(リダイレクト先の絶対URL)
  *     (例)
  *         redirect://login             (現在のページからの相対パス)
  *         redirect:///UserAction/login (サーブレットコンテキストを起点とする相対パス)
  *         http://www.example.com/login (外部サイトのURL)
+ *         redirect:myapp://example.com (モバイルアプリのカスタムスキームを持つURL)
  *
  * このクラスは不変クラスである。
  * </pre>
@@ -135,6 +137,9 @@ public final class ResourceLocator {
     /** ディレクトリ */
     private final String directory;
 
+    /** 絶対URIを伴うリダイレクトかどうかを表すフラグ */
+    private final boolean redirectWithAbsoluteUri;
+
     /**
      * リソースの文字列表現から{@code ResourceLocator}オブジェクトを生成する。
      * <p/>
@@ -154,6 +159,30 @@ public final class ResourceLocator {
      * @param path リソースの文字列表現
      */
     private ResourceLocator(final String path) {
+
+        //5u13でサポートされた絶対URIを指定するredirectスキームの場合の処理
+        if (path.startsWith("redirect:")
+                //5u12でサポートされている形式のredirectスキームは除外する
+                && path.startsWith("redirect://") == false) {
+
+            final String maybeAbsoluteUri = path.substring("redirect:".length());
+
+            //"redirect:"に続く文字列はスキームを含んだ絶対URIでなければならない
+            if (ResourceLocatorInternalHelper.startsWithScheme(maybeAbsoluteUri) == false) {
+                LOG.logInfo("malformed resource path. resource path = " + path);
+                throw new HttpErrorResponse(400);
+            }
+
+            this.contentPath = path;
+            this.scheme = "redirect";
+            this.path = maybeAbsoluteUri;
+            this.resourceName = "";
+            this.hostname = "";
+            this.directory = "";
+            this.redirectWithAbsoluteUri = true;
+            return;
+        }
+        this.redirectWithAbsoluteUri = false;
 
         final Matcher matcher = EXTRACT_SCHEME_PATTERN.matcher(path);
         final String pathWithoutScheme;
@@ -192,6 +221,18 @@ public final class ResourceLocator {
     }
 
     /**
+     * 絶対URIを伴うリダイレクトかどうかを表すフラグを返す。
+     * 
+     * このメソッドはnablarch-fw-web内部からのみの使用を想定しており、
+     * package privateにしている。
+     * 
+     * @return 絶対URIを伴うリダイレクトかどうかを表すフラグ
+     */
+    boolean isRedirectWithAbsoluteUri() {
+        return redirectWithAbsoluteUri;
+    }
+
+    /**
      * 自身のスキームがhttp(https)スキームかどうかを返す。
      * @return http(https)の場合は{@code true}
      */
@@ -215,7 +256,7 @@ public final class ResourceLocator {
      *          コンテキストクラスローダ上のリソースである場合、常に{@code false}
      */
     public boolean isRelative() {
-        if (scheme.equals("classpath") || isHttpScheme()) {
+        if (scheme.equals("classpath") || isHttpScheme() || redirectWithAbsoluteUri) {
             return false;
         }
         return !path.startsWith("/");

--- a/src/main/java/nablarch/fw/web/ResourceLocator.java
+++ b/src/main/java/nablarch/fw/web/ResourceLocator.java
@@ -169,6 +169,10 @@ public final class ResourceLocator {
 
             //"redirect:"に続く文字列はスキームを含んだ絶対URIでなければならない
             if (ResourceLocatorInternalHelper.startsWithScheme(maybeAbsoluteUri) == false) {
+                //既存コードが不正なスキームを含んでいた場合にログを出力して
+                //400 Bad RequestとなるようHttpErrorResponseを投げている。
+                //そうしている設計の意図を汲めてはいないが、ResourceLocatorクラス内での
+                //統一感を保つため、その設計を踏襲しておく。
                 LOG.logInfo("malformed resource path. resource path = " + path);
                 throw new HttpErrorResponse(400);
             }

--- a/src/main/java/nablarch/fw/web/ResourceLocatorInternalHelper.java
+++ b/src/main/java/nablarch/fw/web/ResourceLocatorInternalHelper.java
@@ -20,7 +20,7 @@ public class ResourceLocatorInternalHelper {
      * 
      * @param path 評価対象となるパス
      * @return {@code path}がschemeとコロンから始まっていれば{@code true}
-     * @see https://tools.ietf.org/html/rfc3986#section-3.1
+     * @see <a href="https://tools.ietf.org/html/rfc3986#section-3.1" rel="nofollow">RFC 3986 Section 3.1. Scheme</a>
      */
     public static boolean startsWithScheme(String path) {
         return STARTS_WITH_SCHEME_PATTERN.matcher(path).matches();

--- a/src/main/java/nablarch/fw/web/ResourceLocatorInternalHelper.java
+++ b/src/main/java/nablarch/fw/web/ResourceLocatorInternalHelper.java
@@ -1,0 +1,38 @@
+package nablarch.fw.web;
+
+import java.util.regex.Pattern;
+
+/**
+ * nablarch-fw-web内でのみ使用する{@link ResourceLocator}の補助クラス。
+ * 
+ * @author Taichi Uragami
+ */
+public class ResourceLocatorInternalHelper {
+
+    /** スキームから開始される文字列であるか検証するための正規表現 */
+    private static final Pattern STARTS_WITH_SCHEME_PATTERN = Pattern
+            .compile("[A-Za-z][A-Za-z0-9+-.]*:.*");
+
+    /**
+     * 渡された{@code path}がschemeとコロンから始まるかどうか判断して結果を返す。
+     * 
+     * schemeの仕様はRFC3986のSection 3.1に準ずる。
+     * 
+     * @param path 評価対象となるパス
+     * @return {@code path}がschemeとコロンから始まっていれば{@code true}
+     * @see https://tools.ietf.org/html/rfc3986#section-3.1
+     */
+    public static boolean startsWithScheme(String path) {
+        return STARTS_WITH_SCHEME_PATTERN.matcher(path).matches();
+    }
+
+    /**
+     * {@link ResourceLocator#isRedirectWithAbsoluteUri()}を中継する。
+     * 
+     * @param resourceLocator リソースロケータ
+     * @return {@link ResourceLocator#isRedirectWithAbsoluteUri()}の戻り値
+     */
+    public static boolean isRedirectWithAbsoluteUri(ResourceLocator resourceLocator) {
+        return resourceLocator.isRedirectWithAbsoluteUri();
+    }
+}

--- a/src/main/java/nablarch/fw/web/ResourceLocatorInternalHelper.java
+++ b/src/main/java/nablarch/fw/web/ResourceLocatorInternalHelper.java
@@ -7,11 +7,18 @@ import java.util.regex.Pattern;
  * 
  * @author Taichi Uragami
  */
-public class ResourceLocatorInternalHelper {
+public final class ResourceLocatorInternalHelper {
 
     /** スキームから開始される文字列であるか検証するための正規表現 */
     private static final Pattern STARTS_WITH_SCHEME_PATTERN = Pattern
             .compile("[A-Za-z][A-Za-z0-9+-.]*:.*");
+
+    /**
+     * インスタンス化させない。
+     */
+    private ResourceLocatorInternalHelper() {
+        //NOP
+    }
 
     /**
      * 渡された{@code path}がschemeとコロンから始まるかどうか判断して結果を返す。

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.fail;
 
 import nablarch.core.util.Builder;
 import nablarch.test.support.tool.Hereis;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.servlet.http.Cookie;
@@ -94,6 +96,16 @@ public class HttpResponseTest {
         res = new HttpResponse("redirect://xxx/yyy");
         assertEquals(302, res.getStatusCode());
 
+    }
+
+    @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
+    @Test
+    public void testAccessorsToHttpStatus5u13NewStyleRedirection() {
+        HttpResponse res = new HttpResponse("redirect:http://action/menu");
+        assertEquals(302, res.getStatusCode());
+
+        res = new HttpResponse("redirect:URN:ISBN:978-4-7741-6931-6");
+        assertEquals(302, res.getStatusCode());
     }
 
     @Test

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.fail;
 import nablarch.core.util.Builder;
 import nablarch.test.support.tool.Hereis;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.servlet.http.Cookie;
@@ -98,7 +97,6 @@ public class HttpResponseTest {
 
     }
 
-    @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
     @Test
     public void testAccessorsToHttpStatus5u13NewStyleRedirection() {
         HttpResponse res = new HttpResponse("redirect:http://action/menu");

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -366,6 +366,38 @@ public class ResourceLocatorFunctionalTest {
     }
 
     /**
+     * 許可されないスキームを指定した場合
+     */
+    @Test
+    public void disallowdScheme() {
+        String scheme = "disallowed";
+        assertThat(ResourceLocator.SCHEMES, not(containsString(scheme)));
+        try {
+            String path = scheme + "://foo/bar";
+            ResourceLocator.valueOf(path);
+            fail();
+        } catch (HttpErrorResponse expected) {
+            assertThat(expected.getResponse().getStatusCode(), is(400));
+        }
+    }
+
+    /**
+     * ディレクトリが許可されない文字を含んでいた場合
+     */
+    @Test
+    public void httpContentDisallowedDirectory() {
+        String directory = "x..z";
+        assertThat(ResourceLocator.ALLOWED_CHAR.matcher(directory).matches(), is(false));
+        try {
+            String path = "http://yourhost.com/" + directory + "/index.html";
+            ResourceLocator.valueOf(path);
+            fail();
+        } catch (HttpErrorResponse expected) {
+            assertThat(expected.getResponse().getStatusCode(), is(400));
+        }
+    }
+
+    /**
      * classpathとfile scheme以外で不正なオペレーションのアサートをする
      *
      * @param sut

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -12,7 +12,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 
-import org.hamcrest.text.IsEmptyString;
 import org.junit.Test;
 
 /**

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -160,7 +160,7 @@ public class ResourceLocatorFunctionalTest {
     }
 
     /**
-     * reidirect schemeの場合
+     * redirect schemeの場合
      *
      * @throws Exception
      */
@@ -398,7 +398,7 @@ public class ResourceLocatorFunctionalTest {
     }
 
     /**
-     * reidirect schemeで絶対URLを指定した場合
+     * redirect schemeで絶対URLを指定した場合
      */
     @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
     @Test
@@ -421,7 +421,7 @@ public class ResourceLocatorFunctionalTest {
     }
 
     /**
-     * reidirect schemeで{@link ResourceLocator#SCHEMES 対応するスキーム名}以外のURIを指定した場合
+     * redirect schemeで{@link ResourceLocator#SCHEMES 対応するスキーム名}以外のURIを指定した場合
      */
     @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
     @Test

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -380,7 +380,7 @@ public class ResourceLocatorFunctionalTest {
      * 許可されないスキームを指定した場合
      */
     @Test
-    public void disallowdScheme() {
+    public void disallowedScheme() {
         String scheme = "disallowed";
         assertThat(ResourceLocator.SCHEMES, not(containsString(scheme)));
         try {

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -329,6 +329,43 @@ public class ResourceLocatorFunctionalTest {
     }
 
     /**
+     * file schemeで存在しないファイルを指定した場合
+     */
+    @Test
+    public void fileContentNotExists() throws Exception {
+
+        final ResourceLocator sut = ResourceLocator.valueOf(
+                "file://src/test/resources/nablarch/fw/web/resourceLocator/notExists");
+
+        assertThat(sut, allOf(
+                hasProperty("scheme", is("file")),
+                hasProperty("resourceName", is("notExists")),
+                hasProperty("path", is("src/test/resources/nablarch/fw/web/resourceLocator/notExists")),
+                hasProperty("realPath", containsString("notExists")),
+                hasProperty("redirect", is(false)),
+                hasProperty("relative", is(true)),
+                hasProperty("hostname", isEmptyString()),
+                hasProperty("directory", is("src/test/resources/nablarch/fw/web/resourceLocator/"))
+        ));
+        assertThat("存在しないファイルなのでfalse", sut.exists(), is(false));
+        assertThat(sut.toString(),
+                is("file://src/test/resources/nablarch/fw/web/resourceLocator/notExists"));
+
+        // 存在しないファイルなのでアクセスできない
+        try {
+            sut.getReader();
+            fail("");
+        } catch (FileNotFoundException ignore) {
+        }
+        try {
+            sut.getInputStream();
+            fail("");
+        } catch (FileNotFoundException ignore) {
+        }
+
+    }
+
+    /**
      * classpathとfile scheme以外で不正なオペレーションのアサートをする
      *
      * @param sut

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -36,6 +36,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("directory", is("/hoge/fuga/")),
                 hasProperty("path", is("/hoge/fuga/image.png"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("httpでは存在チェックが無効(false)", sut.exists(), is(false));
         assertThat(sut.toString(), is("http://yourhost.com/hoge/fuga/image.png"));
 
@@ -59,6 +60,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("directory", is("/hoge/fuga/")),
                 hasProperty("path", is("/hoge/fuga/content?aa=bb#aa=bb"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("httpsでは存在チェックが無効(false)", sut.exists(), is(false));
         assertThat(sut.toString(), is("https://yourhost.com/hoge/fuga/content?aa=bb#aa=bb"));
 
@@ -82,6 +84,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("directory", is("")),
                 hasProperty("path", is(""))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         
         assertThat("httpでは存在チェックが無効(false)", sut.exists(), is(false));
         assertThat(sut.toString(), is("http://"));
@@ -107,6 +110,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("/WEB-INF/users/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("servletの場合は常にtrue", sut.exists(), is(true));
         assertThat(sut.toString(), is("servlet:///WEB-INF/users/index.jsp"));
 
@@ -129,6 +133,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("/WEB-INF/users/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("servletの場合は常にtrue", sut.exists(), is(true));
         assertThat(sut.toString(), is("servlet:///WEB-INF/users/index.jsp"));
         
@@ -151,6 +156,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", isEmptyString())
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("forwardの場合は常にtrue", sut.exists(), is(true));
         assertThat(sut.toString(), is("forward://index"));
 
@@ -175,6 +181,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("/action/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("redirectの場合は常にfalse", sut.exists(), is(false));
         assertThat(sut.toString(), is("redirect:///action/menu"));
 
@@ -197,6 +204,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("users/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("デフォルト(servlet)の場合は常にtrue", sut.exists(), is(true));
         assertThat(sut.toString(), is("servlet://users/index.jsp"));
 
@@ -221,6 +229,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("/nablarch/fw/web/resourceLocator/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("存在しているのでtrue", sut.exists(), is(true));
         assertThat(sut.toString(), is("classpath:///nablarch/fw/web/resourceLocator/classpathResource.txt"));
 
@@ -246,6 +255,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("/nablarch/fw/web/resourceLocator/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("存在していないのでfalse", sut.exists(), is(false));
         assertThat(sut.toString(), is("classpath:///nablarch/fw/web/resourceLocator/not_exists.txt"));
 
@@ -281,6 +291,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("src/test/resources/nablarch/fw/web/resourceLocator/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("存在している", sut.exists(), is(true));
         assertThat(sut.toString(),
                 is("file://src/test/resources/nablarch/fw/web/resourceLocator/classpathResource.txt"));
@@ -308,6 +319,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("src/test/resources/nablarch/fw/web/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("ディレクトリはファイルとして扱えないのでfalse", sut.exists(), is(false));
         assertThat(sut.toString(),
                 is("file://src/test/resources/nablarch/fw/web/resourceLocator"));
@@ -345,6 +357,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("src/test/resources/nablarch/fw/web/resourceLocator/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("存在しないファイルなのでfalse", sut.exists(), is(false));
         assertThat(sut.toString(),
                 is("file://src/test/resources/nablarch/fw/web/resourceLocator/notExists"));
@@ -411,6 +424,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", isEmptyString())
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(true));
         assertThat("redirectの場合は常にfalse", sut.exists(), is(false));
         assertThat(sut.toString(), is("redirect:http://action/menu"));
 
@@ -433,6 +447,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", isEmptyString())
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(true));
         assertThat("redirectの場合は常にfalse", sut.exists(), is(false));
         assertThat(sut.toString(), is("redirect:URN:ISBN:978-4-7741-6931-6"));
 
@@ -455,6 +470,7 @@ public class ResourceLocatorFunctionalTest {
                 hasProperty("hostname", isEmptyString()),
                 hasProperty("directory", is("foo/"))
         ));
+        assertThat(sut.isRedirectWithAbsoluteUri(), is(false));
         assertThat("redirectの場合は常にfalse", sut.exists(), is(false));
         assertThat(sut.toString(), is("redirect://foo/bar"));
 

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -298,21 +298,21 @@ public class ResourceLocatorFunctionalTest {
     public void directoryContent() throws Exception {
 
         final ResourceLocator sut = ResourceLocator.valueOf(
-                "file:///src/test/resources/nablarch/fw/web/resourceLocator");
+                "file://src/test/resources/nablarch/fw/web/resourceLocator");
 
         assertThat(sut, allOf(
                 hasProperty("scheme", is("file")),
                 hasProperty("resourceName", is("resourceLocator")),
-                hasProperty("path", is("/src/test/resources/nablarch/fw/web/resourceLocator")),
+                hasProperty("path", is("src/test/resources/nablarch/fw/web/resourceLocator")),
                 hasProperty("realPath", containsString("resourceLocator")),
                 hasProperty("redirect", is(false)),
-                hasProperty("relative", is(false)),
+                hasProperty("relative", is(true)),
                 hasProperty("hostname", isEmptyString()),
-                hasProperty("directory", is("/src/test/resources/nablarch/fw/web/"))
+                hasProperty("directory", is("src/test/resources/nablarch/fw/web/"))
         ));
         assertThat("ディレクトリはファイルとして扱えないのでfalse", sut.exists(), is(false));
         assertThat(sut.toString(),
-                is("file:///src/test/resources/nablarch/fw/web/resourceLocator"));
+                is("file://src/test/resources/nablarch/fw/web/resourceLocator"));
 
         // ディレクトリなのでアクセスできない
         try {

--- a/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorFunctionalTest.java
@@ -14,7 +14,7 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 
 import org.hamcrest.text.IsEmptyString;
-
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -397,6 +397,52 @@ public class ResourceLocatorFunctionalTest {
         }
     }
 
+    /**
+     * reidirect schemeで絶対URLを指定した場合
+     */
+    @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
+    @Test
+    public void redirectContentAbsoluteURL() {
+        final ResourceLocator sut = ResourceLocator.valueOf("redirect:http://action/menu");
+
+        assertThat(sut, allOf(
+                hasProperty("scheme", is("redirect")),
+                hasProperty("resourceName", isEmptyString()),
+                hasProperty("path", is("http://action/menu")),
+                hasProperty("redirect", is(true)),
+                hasProperty("relative", is(false)),
+                hasProperty("hostname", isEmptyString()),
+                hasProperty("directory", isEmptyString())
+        ));
+        assertThat("redirectの場合は常にfalse", sut.exists(), is(false));
+        assertThat(sut.toString(), is("redirect:http://action/menu"));
+
+        invalidOperationWithoutClasspathAndFileScheme(sut);
+    }
+
+    /**
+     * reidirect schemeで{@link ResourceLocator#SCHEMES 対応するスキーム名}以外のURIを指定した場合
+     */
+    @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
+    @Test
+    public void redirectContentUnknownSchemes() {
+        final ResourceLocator sut = ResourceLocator.valueOf("redirect:URN:ISBN:978-4-7741-6931-6");
+
+        assertThat(sut, allOf(
+                hasProperty("scheme", is("redirect")),
+                hasProperty("resourceName", isEmptyString()),
+                hasProperty("path", is("URN:ISBN:978-4-7741-6931-6")),
+                hasProperty("redirect", is(true)),
+                hasProperty("relative", is(false)),
+                hasProperty("hostname", isEmptyString()),
+                hasProperty("directory", isEmptyString())
+        ));
+        assertThat("redirectの場合は常にfalse", sut.exists(), is(false));
+        assertThat(sut.toString(), is("redirect:URN:ISBN:978-4-7741-6931-6"));
+
+        invalidOperationWithoutClasspathAndFileScheme(sut);
+    }
+    
     /**
      * classpathとfile scheme以外で不正なオペレーションのアサートをする
      *

--- a/src/test/java/nablarch/fw/web/ResourceLocatorInternalHelperStartsWithSchemeTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorInternalHelperStartsWithSchemeTest.java
@@ -13,7 +13,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * {@link ResourceLocator#startsWithScheme(String)}のテスト
+ * {@link ResourceLocatorInternalHelper#startsWithScheme(String)}のテスト
  */
 @RunWith(Parameterized.class)
 public class ResourceLocatorInternalHelperStartsWithSchemeTest {

--- a/src/test/java/nablarch/fw/web/ResourceLocatorInternalHelperStartsWithSchemeTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorInternalHelperStartsWithSchemeTest.java
@@ -1,0 +1,67 @@
+package nablarch.fw.web;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * {@link ResourceLocator#startsWithScheme(String)}のテスト
+ */
+@RunWith(Parameterized.class)
+public class ResourceLocatorInternalHelperStartsWithSchemeTest {
+
+    @Parameter(0)
+    public Fixture fixture;
+
+    @Test
+    public void test() {
+        boolean actual = ResourceLocatorInternalHelper.startsWithScheme(fixture.path);
+        assertThat(actual, is(fixture.expected));
+    }
+
+    @Parameters(name = "{0}")
+    public static List<Fixture> parameters() {
+        List<Fixture> fixtures = new ArrayList<Fixture>();
+        Fixture.addTo(fixtures, "絶対URI", "http://foo/bar", true);
+        Fixture.addTo(fixtures, "ResourceLocatorが知らないスキーム", "URN:ISBN:978-4-7741-6931-6", true);
+        Fixture.addTo(fixtures, "スキームを構成する文字はアルファベット、数字、+、-、.が許可される", "abcXYZ012+-.:foo/bar", true);
+
+        Fixture.addTo(fixtures, "相対URI", "foo/bar", false);
+        Fixture.addTo(fixtures, "最初のコロンの前にスキームが無い", ":foo:bar", false);
+        Fixture.addTo(fixtures, "スキームに許可されない文字（/）を含んでいる", "foo/bar:baz", false);
+        Fixture.addTo(fixtures, "スキームの最初の文字はアルファベットでなければならない", "12factor:app", false);
+        Fixture.addTo(fixtures, "空文字列", "", false);
+        return fixtures;
+    }
+
+    private static class Fixture {
+
+        private final String description;
+        private final String path;
+        private final boolean expected;
+
+        public Fixture(String description, String path, boolean expected) {
+            this.description = description;
+            this.path = path;
+            this.expected = expected;
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+
+        static void addTo(List<Fixture> fixtures, String description, String path,
+                boolean expected) {
+            fixtures.add(new Fixture(description, path, expected));
+        }
+    }
+}

--- a/src/test/java/nablarch/fw/web/ResourceLocatorTest.java
+++ b/src/test/java/nablarch/fw/web/ResourceLocatorTest.java
@@ -22,7 +22,6 @@ import nablarch.test.IgnoringLS;
 import nablarch.test.support.tool.Hereis;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -246,33 +245,6 @@ public class ResourceLocatorTest {
         assertEquals("/", redirection.getDirectory());
         assertEquals("?foo=fuga"
           , redirection.getResourceName());
-    }
-
-    @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
-    @Test
-    public void test5u13NewSyntaxOfResourcePathWithTheRedirectionScheme() {
-
-        ResourceLocator redirection = null;
-
-        redirection = new HttpResponse("redirect:http://localhost:8080/templates/index.html")
-                .getContentPath();
-
-        assertEquals("redirect:http://localhost:8080/templates/index.html", redirection.toString());
-        assertEquals("redirect",                                            redirection.getScheme());
-        assertEquals("",                                                    redirection.getHostname());
-        assertEquals("http://localhost:8080/templates/index.html",          redirection.getPath());
-        assertEquals("",                                                    redirection.getDirectory());
-        assertEquals("",                                                    redirection.getResourceName());
-        
-        redirection = new HttpResponse("redirect:URN:ISBN:978-4-7741-6931-6")
-                         .getContentPath();
-
-        assertEquals("redirect:URN:ISBN:978-4-7741-6931-6", redirection.toString());
-        assertEquals("redirect",                            redirection.getScheme());
-        assertEquals("",                                    redirection.getHostname());
-        assertEquals("URN:ISBN:978-4-7741-6931-6",          redirection.getPath());
-        assertEquals("",                                    redirection.getDirectory());
-        assertEquals("",                                    redirection.getResourceName());
     }
 
     @Test
@@ -638,56 +610,6 @@ public class ResourceLocatorTest {
         assertEquals("https://www.example.com/secure.html", res.getLocation());
     }
 
-
-    /**
-     * 5u13からサポートされた形式のリダイレクション処理のテスト
-     */
-    @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
-    @Test
-    public void testRedirection5u13NewFeature() {
-        HttpServer server = new HttpServer()
-        .setWarBasePath("classpath://nablarch/fw/web/sample/app/")
-        .setServletContextPath("/app")
-        .addHandler("/test/Greeting", new HttpRequestHandler() {
-            @Override
-            public HttpResponse handle(HttpRequest req, ExecutionContext ctx) {
-                ctx.invalidateSession();
-                ctx.setRequestScopedVar("greeting", "Hello World!");
-                return new HttpResponse().setContentPath(
-                    "redirect:http://foo/bar"
-                );
-            }
-        })
-        .addHandler("/test/Greeting2", new HttpRequestHandler() {
-            @Override
-            public HttpResponse handle(HttpRequest req, ExecutionContext ctx) {
-                ctx.setRequestScopedVar("greeting", "Hello World!");
-                return new HttpResponse().setContentPath(
-                    "redirect:URN:ISBN:978-4-7741-6931-6"
-                );
-            }
-        })
-        .startLocal();
-
-        HttpResponse res = server.handle(new MockHttpRequest(string()), null);
-        /*************************
-        GET /app/test/Greeting HTTP/1.1
-        **************************/
-
-        assertEquals(302, res.getStatusCode());
-        // Locationはサーブレットコンテナ出力
-        assertEquals("http://foo/bar", res.getLocation());
-
-
-        res = server.handle(new MockHttpRequest(string()), null);
-        /*************************
-        GET /app/test/Greeting2 HTTP/1.1
-        **************************/
-
-        assertEquals(302, res.getStatusCode());
-        // Locationはサーブレットコンテナ出力
-        assertEquals("URN:ISBN:978-4-7741-6931-6", res.getLocation());
-    }
 
     @Test
     public void testIsRelative() {

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -936,7 +936,6 @@ public class HttpResponseHandlerTest {
                 })
                 .startLocal();
 
-        // 内部リソースへのリダイレクトの場合、jsessionidが付与されること。
         HttpResponse res = server.handle(new MockHttpRequest("GET /redirect HTTP/1.1"), null);
         assertThat("ステータスコードがリダイレクトであること。",
                 res.getStatusCode(), is(302));

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -44,7 +44,6 @@ import nablarch.test.support.log.app.OnMemoryLogWriter;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -924,7 +923,6 @@ public class HttpResponseHandlerTest {
     }
 
     /** 5u13から導入された形式のリダイレクトの場合、リダイレクト先のURLにjsessionidが付与されないこと。 */
-    @Ignore("5u12の仕様ではパスしないテストケース。リダイレクトの仕様変更にあわせてテストを実施するため、@Ignoreを付けている。")
     @Test
     public void testJsessionidNotAddedWhenRedirectedSince5u13NewStyle() {
         HttpServer server = new HttpServer()
@@ -942,7 +940,8 @@ public class HttpResponseHandlerTest {
         assertThat("ステータスコードがリダイレクトであること。",
                 res.getStatusCode(), is(302));
         String jsessionid = getCookieValue(res.getHeader("Set-Cookie"), "JSESSIONID");
-        assertThat("jsessionidが発行されていないこと。", jsessionid, is(nullValue()));
+        //セッションが作られること自体に問題はない
+        assertThat("jsessionidが発行されていること。", jsessionid, is(notNullValue()));
         assertThat("リダイレクト先URLにjsessionidが付与されていないこと。",
                 res.getLocation(), not(containsString("jsessionid=")));
     }

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -927,9 +927,10 @@ public class HttpResponseHandlerTest {
     public void testJsessionidNotAddedWhenRedirectedSince5u13NewStyle() {
         HttpServer server = new HttpServer()
                 .setWarBasePath("classpath://nablarch/fw/web/sample/app/")
-                .addHandler(new SessionConcurrentAccessHandler())
                 .addHandler("/redirect", new HttpRequestHandler() {
                     public HttpResponse handle(HttpRequest req, ExecutionContext ctx) {
+                        //セッションを作る
+                        ctx.getSessionScopeMap();
                         return new HttpResponse().setContentPath("redirect:http://foo/bar/index.jsp");
                     }
                 })


### PR DESCRIPTION
次のようなリダイレクトを表す `ResourceLocator` を構築できるようにするのがゴールです。

```
ResourceLocator.valueOf("redirect:http://foo/bar");
ResourceLocator.valueOf("redirect:URN:ISBN:978-4-7741-6931-6");
```

この新しい形式のリダイレクトを表す `ResourceLocator` においては次のメソッドは空文字列を返すようにしようと考えています。

* `getResourceName`
* `getHostname`
* `getDirectory`

このうち `getResourceName` は `HttpResponse.setContentPath` の中で `Content-Type` を暗黙的に設定するために使用されていますが、リダイレクトはレスポンスボディを持たず `Content-Type` の設定は意味をなさないので今回追加するリダイレクトのケースで `getResourceName` が空文字列を返しても問題はないと考えています。
`getHostname` と `getDirectory` は少なくとも `fw-web` のプロダクションコード内では使われていません。