### PR TITLE
Content-Dispositionでfilename*パラメーターを出力する

### DIFF
--- a/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
+++ b/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
@@ -171,7 +171,7 @@ class ContentDispositionRawValue {
             if (isFilenameParam && containsFilenameExtParam == false) {
                 buf.append("; ")
                         .append(FILENAME_EXT_PARAM_NAME)
-                        .append("=")
+                        .append('=')
                         .append("UTF-8''").append(UTF8_URL_ENCODER.encode(value));
             }
 

--- a/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
+++ b/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
@@ -102,10 +102,24 @@ class ContentDispositionRawValue {
         return buf.toString();
     }
 
+    /**
+     * パラメーターのキーを正規化する。
+     * 
+     * <p>
+     * パラメーターのキーはcase insensitiveなので検索のために正規化する。
+     * </p>
+     * 
+     * @param key 正規化する前のキー
+     * @return 正規化したキー
+     */
     private static String normalizeKey(String key) {
         return key.toLowerCase();
     }
 
+    /**
+     * Content-Dispositionヘッダの値が含んでいるパラメーターを表すクラス。
+     *
+     */
     private class Param {
 
         /** コンストラクタで受け取ったキー */

--- a/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
+++ b/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
@@ -1,7 +1,13 @@
 package nablarch.fw.web.handler;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import nablarch.fw.web.download.encorder.DownloadFileNameEncoder;
+import nablarch.fw.web.download.encorder.UrlDownloadFileNameEncoder;
 
 /**
  * エンコードされていない生のContent-Dispositionヘッダ値を表すクラス。
@@ -11,8 +17,30 @@ import java.util.regex.Pattern;
  */
 class ContentDispositionRawValue {
 
-    private final Matcher matcher;
-    private final boolean matched;
+    /** filenameキー */
+    private static final String FILENAME_PARAM_NAME = normalizeKey("filename");
+    /** filename*キー */
+    private static final String FILENAME_EXT_PARAM_NAME = normalizeKey("filename*");
+    /** disposition-typeを抽出するための正規表現 */
+    private static final Pattern TYPE_PATTERN = Pattern.compile("\\s*([^;\\s]+)");
+    /** パラメーターを抽出するための正規表現 */
+    private static final Pattern PARAM_PATTERN = Pattern
+            .compile("\\s*;\\s*([^=\\s]+)\\s*=\\s*([^;\\s]+)");
+    /** UTF-8でURLエンコードをする{@link DownloadFileNameEncoder} */
+    private static final UrlDownloadFileNameEncoder UTF8_URL_ENCODER = new UrlDownloadFileNameEncoder();
+
+    /**
+     * inline、attachementなどのdisposition-type
+     * 
+     * @see <a href="https://tools.ietf.org/html/rfc6266#section-4.2">https://tools.ietf.org/html/rfc6266#section-4.2</a>
+     */
+    private final String type;
+    /** パラメーターのリスト */
+    private final List<Param> params;
+    /** filenameパラメーター。nullの場合もある。 */
+    private final Param filenameParam;
+    /** filename*パラメーターを保持している場合はtrue */
+    private final boolean containsFilenameExtParam;
 
     /**
      * コンストラクタ。
@@ -20,9 +48,25 @@ class ContentDispositionRawValue {
      * @param rawValue エンコードされていない生のContent-Dispositionヘッダ値
      */
     public ContentDispositionRawValue(final String rawValue) {
-        Pattern pattern = Pattern.compile("(.*filename=\")(.*)(\".*)");
-        this.matcher = pattern.matcher(rawValue);
-        this.matched = this.matcher.matches();
+        final Matcher typeMatcher = TYPE_PATTERN.matcher(rawValue);
+        typeMatcher.find();
+        this.type = typeMatcher.group(1);
+
+        int index = typeMatcher.group().length();
+
+        final LinkedHashMap<String, Param> paramMap = new LinkedHashMap<String, Param>();
+        final Matcher paramMatcher = PARAM_PATTERN.matcher(rawValue);
+        while (paramMatcher.find(index)) {
+            final String key = paramMatcher.group(1);
+            final String value = paramMatcher.group(2);
+            final Param param = new Param(key, value);
+            param.putTo(paramMap);
+            index += paramMatcher.group().length();
+        }
+        this.params = new ArrayList<Param>(paramMap.values());
+
+        this.filenameParam = paramMap.get(FILENAME_PARAM_NAME);
+        this.containsFilenameExtParam = paramMap.containsKey(FILENAME_EXT_PARAM_NAME);
     }
 
     /**
@@ -31,7 +75,7 @@ class ContentDispositionRawValue {
      * @return エンコードする必要があればtrue
      */
     public boolean needsToBeEncoded() {
-        return matched;
+        return filenameParam != null && filenameParam.quoted;
     }
 
     /**
@@ -40,7 +84,7 @@ class ContentDispositionRawValue {
      * @return エンコードされていないファイル名
      */
     public String getRawFileName() {
-        return matcher.group(2);
+        return filenameParam.value;
     }
 
     /**
@@ -50,6 +94,90 @@ class ContentDispositionRawValue {
      * @return エンコード済みのContent-Dispositionヘッダ値
      */
     public String buildEncodedValue(final String encodedFileName) {
-        return matcher.replaceFirst("$1" + encodedFileName + "$3");
+        final StringBuilder buf = new StringBuilder();
+        buf.append(type);
+        for (Param param : params) {
+            param.appendTo(buf, encodedFileName);
+        }
+        return buf.toString();
+    }
+
+    private static String normalizeKey(String key) {
+        return key.toLowerCase();
+    }
+
+    private class Param {
+
+        /** コンストラクタで受け取ったキー */
+        final String originalKey;
+        /**
+         * キーに{@link ContentDispositionRawValue#normalizeKey(String)}を適用したもの。
+         * キーの比較には{@link #originalKey}ではなくこちらを使用する。
+         */
+        final String normalizedKey;
+        /** 値。ダブルクォートで囲まれていた場合はダブルクォートが取り除かれた状態 */
+        final String value;
+        /** 値がダブルクォートで囲まれていたか */
+        final boolean quoted;
+
+        /**
+         * コンストラクタ。
+         * 
+         * @param key キー
+         * @param value 値
+         */
+        Param(final String key, final String value) {
+            this.originalKey = key;
+            this.normalizedKey = normalizeKey(key);
+            if (value.charAt(0) == '"') {
+                this.value = value.substring(1, value.length() - 1);
+                this.quoted = true;
+            } else {
+                this.value = value;
+                this.quoted = false;
+            }
+        }
+
+        /**
+         * StringBuilderへパラメーターを追加する。
+         * 
+         * <p>
+         * 自身がfilenameパラメーターなら引数で受け取ったencodedFileNameを値として追加する。
+         * また、自身がfilenameパラメーターかつ明示的にfilename*パラメーターが設定されていない場合、
+         * filenameパラメーターに設定された値をもとにしてfilename*パラメーターを追加する。
+         * </p>
+         * 
+         * @param buf ここにパラメーターが追加される
+         * @param encodedFileName エンコード済みのファイル名
+         */
+        void appendTo(final StringBuilder buf, final String encodedFileName) {
+
+            final boolean isFilenameParam = normalizedKey.equals(FILENAME_PARAM_NAME);
+
+            if (isFilenameParam && containsFilenameExtParam == false) {
+                buf.append("; ")
+                        .append(FILENAME_EXT_PARAM_NAME)
+                        .append("=")
+                        .append("UTF-8''").append(UTF8_URL_ENCODER.encode(value));
+            }
+
+            buf.append("; ").append(originalKey).append('=');
+            if (quoted) {
+                buf.append('"');
+            }
+            buf.append(isFilenameParam ? encodedFileName : value);
+            if (quoted) {
+                buf.append('"');
+            }
+        }
+
+        /**
+         * 引数で渡された{@link LinkedHashMap}に自身を加える。
+         * 
+         * @param paramMap ここに自身を加える
+         */
+        void putTo(final LinkedHashMap<String, Param> paramMap) {
+            paramMap.put(normalizedKey, this);
+        }
     }
 }

--- a/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
+++ b/src/main/java/nablarch/fw/web/handler/ContentDispositionRawValue.java
@@ -1,0 +1,55 @@
+package nablarch.fw.web.handler;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * エンコードされていない生のContent-Dispositionヘッダ値を表すクラス。
+ * 
+ * @author Taichi Uragami
+ *
+ */
+class ContentDispositionRawValue {
+
+    private final Matcher matcher;
+    private final boolean matched;
+
+    /**
+     * コンストラクタ。
+     * 
+     * @param rawValue エンコードされていない生のContent-Dispositionヘッダ値
+     */
+    public ContentDispositionRawValue(final String rawValue) {
+        Pattern pattern = Pattern.compile("(.*filename=\")(.*)(\".*)");
+        this.matcher = pattern.matcher(rawValue);
+        this.matched = this.matcher.matches();
+    }
+
+    /**
+     *エンコードする必要があるかどうかを返す。
+     * 
+     * @return エンコードする必要があればtrue
+     */
+    public boolean needsToBeEncoded() {
+        return matched;
+    }
+
+    /**
+     * エンコードされていないファイル名を取得する。
+     * 
+     * @return エンコードされていないファイル名
+     */
+    public String getRawFileName() {
+        return matcher.group(2);
+    }
+
+    /**
+     * エンコード済みのContent-Dispositionヘッダ値を組み立てる。
+     * 
+     * @param encodedFileName エンコード済みのファイル名
+     * @return エンコード済みのContent-Dispositionヘッダ値
+     */
+    public String buildEncodedValue(final String encodedFileName) {
+        return matcher.replaceFirst("$1" + encodedFileName + "$3");
+    }
+}

--- a/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
@@ -6,8 +6,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.SocketException;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
@@ -450,16 +448,15 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
      */
     private String replaceContentDisposition(String dispositionValue,
                                                     HttpServletRequest nativeReq) {
-        Pattern pattern = Pattern.compile("(.*filename=\")(.*)(\".*)");
-        Matcher matcher = pattern.matcher(dispositionValue);
-        if (!matcher.matches()) {
+        ContentDispositionRawValue cdrv = new ContentDispositionRawValue(dispositionValue);
+        if (cdrv.needsToBeEncoded() == false) {
             return dispositionValue;
         }
         String userAgent = nativeReq.getHeader(USER_AGENT);
         DownloadFileNameEncoder
         encoder = downloadFileNameEncoderFactory.getEncoder(userAgent);
-        String encodedFileName = encoder.encode(matcher.group(2));
-        return matcher.replaceFirst("$1" + encodedFileName + "$3");
+        String encodedFileName = encoder.encode(cdrv.getRawFileName());
+        return cdrv.buildEncodedValue(encodedFileName);
     }
 
     /**

--- a/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
+++ b/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
@@ -37,52 +37,86 @@ public class ContentDispositionRawValueTest {
         sut = new ContentDispositionRawValue(fixture.rawValue);
     }
 
+    /**
+     * {@link ContentDispositionRawValue#needsToBeEncoded()}のテスト。
+     */
     @Test
     public void needsToBeEncoded() {
         assertThat(sut.needsToBeEncoded(), is(fixture.expectedNeedsToBeEncoded));
     }
 
+    /**
+     * {@link ContentDispositionRawValue#getRawFileName()}のテスト。
+     * 
+     * {@link ContentDispositionRawValue#needsToBeEncoded()}がfalseの場合はエンコード不要なのでテストをスキップする。
+     */
     @Test
     public void getRawFileName() {
         Assume.assumeTrue(fixture.rawValue + " はエンコード不要", sut.needsToBeEncoded());
         assertThat(sut.getRawFileName(), is(fixture.expectedGetRawFileName));
     }
 
+    /**
+     * {@link ContentDispositionRawValue#buildEncodedValue(String)}のテスト。
+     * 
+     * {@link ContentDispositionRawValue#needsToBeEncoded()}がfalseの場合はエンコード不要なのでテストをスキップする。
+     */
     @Test
     public void buildEncodedValue() {
         Assume.assumeTrue(fixture.rawValue + " はエンコード不要", sut.needsToBeEncoded());
-        assertThat(sut.buildEncodedValue("エンコード済み.txt"), is(fixture.expectedBuildEncodedValue));
+        assertThat(sut.buildEncodedValue("ENCODEDFILENAME"), is(fixture.expectedBuildEncodedValue));
     }
 
     @Parameters(name = "{0}")
     public static List<Fixture> parameters() {
 
-        String nothing = null;
-
         List<Fixture> fixtures = new ArrayList<Fixture>();
 
-        fixtures.add(new Fixture("attachment; filename=\"ファイル名.txt\"",
-                true, "ファイル名.txt",
-                "attachment; filename*=UTF-8''%E3%82%A8%E3%83%B3%E3%82%B3%E3%83%BC%E3%83%89%E6%B8%88%E3%81%BF.txt; filename=\"エンコード済み.txt\""));
+        Fixture.testCase("attachment; filename=\"ファイル名.txt\"")
+                .expect("ファイル名.txt",
+                        "attachment; filename*=UTF-8''%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E5%90%8D.txt; filename=\"ENCODEDFILENAME\"")
+                .addTo(fixtures, "filename*パラメーターが追加されてエンコードする");
 
-        fixtures.add(new Fixture("inline; filename=\"ファイル名.txt\"",
-                true, "ファイル名.txt",
-                "inline; filename*=UTF-8''%E3%82%A8%E3%83%B3%E3%82%B3%E3%83%BC%E3%83%89%E6%B8%88%E3%81%BF.txt; filename=\"エンコード済み.txt\""));
+        Fixture.testCase("inline; filename=\"ファイル名.txt\"")
+                .expect("ファイル名.txt",
+                        "inline; filename*=UTF-8''%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E5%90%8D.txt; filename=\"ENCODEDFILENAME\"")
+                .addTo(fixtures, "disposition-typeがinlineの場合もエンコードする");
 
-        fixtures.add(new Fixture("attachment; filename=hoge.txt",
-                false, nothing, nothing));
+        Fixture.testCase("attachment; filename=hoge.txt")
+                .expectNoEncoding()
+                .addTo(fixtures, "ダブルクォートで囲まれていない場合はエンコードしない");
 
-        fixtures.add(new Fixture("attachment; filename=\"hoge.txt\"",
-                true, "hoge.txt",
-                "attachment; filename*=UTF-8''%E3%82%A8%E3%83%B3%E3%82%B3%E3%83%BC%E3%83%89%E6%B8%88%E3%81%BF.txt; filename=\"エンコード済み.txt\""));
+        Fixture.testCase("attachment; filename=\"hoge.txt\"")
+                .expect("hoge.txt",
+                        "attachment; filename*=UTF-8''hoge.txt; filename=\"ENCODEDFILENAME\"")
+                .addTo(fixtures, "アルファベットとピリオドからなるファイル名でもダブルクォートで囲んだ場合はエンコードする");
 
-        fixtures.add(new Fixture("attachment",
-                false, nothing, nothing));
+        Fixture.testCase("attachment")
+                .expectNoEncoding()
+                .addTo(fixtures, "disposition-typeしかない場合はエンコードしない");
+
+        //これ以降は念のためテスト
+
+        Fixture.testCase("attachment; filename=\"ファイル名.txt\";ext1=foo  ;    ext2=bar")
+                .expect("ファイル名.txt",
+                        "attachment; filename*=UTF-8''%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E5%90%8D.txt; filename=\"ENCODEDFILENAME\"; ext1=foo; ext2=bar")
+                .addTo(fixtures, "filename以外のパラメーターが設定されている場合");
+
+        Fixture.testCase("attachment; filename=\"ファイル名.txt\"; filename*=UTF-8''ALREADY.txt")
+                .expect("ファイル名.txt",
+                        "attachment; filename=\"ENCODEDFILENAME\"; filename*=UTF-8''ALREADY.txt")
+                .addTo(fixtures, "filename*パラメーターが既に設定されている場合は設定値を優先する");
+
+        Fixture.testCase("attachment; filename*=UTF-8''ALREADY.txt")
+                .expectNoEncoding()
+                .addTo(fixtures, "filename*パラメーターしかない場合はエンコードしない");
 
         return fixtures;
     }
 
     private static class Fixture {
+
+        private final String testCaseName;
 
         /**
          * Content-Dispositionの値（ただしfilenameはエンコードしていない）。
@@ -100,8 +134,9 @@ public class ContentDispositionRawValueTest {
         /** {@link ContentDispositionRawValue#buildEncodedValue(String)}の期待値 */
         final String expectedBuildEncodedValue;
 
-        public Fixture(String rawValue, boolean expectedNeedsToBeEncoded,
+        public Fixture(String testCaseName, String rawValue, boolean expectedNeedsToBeEncoded,
                 String expectedGetRawFileName, String expectedBuildEncodedValue) {
+            this.testCaseName = testCaseName;
             this.rawValue = rawValue;
             this.expectedNeedsToBeEncoded = expectedNeedsToBeEncoded;
             this.expectedGetRawFileName = expectedGetRawFileName;
@@ -113,7 +148,39 @@ public class ContentDispositionRawValueTest {
          */
         @Override
         public String toString() {
-            return rawValue;
+            return testCaseName;
+        }
+
+        static Builder testCase(String rawValue) {
+            Builder builder = new Builder();
+            builder.rawValue = rawValue;
+            return builder;
+        }
+
+        private static class Builder {
+            String rawValue;
+            boolean expectedNeedsToBeEncoded;
+            String expectedGetRawFileName;
+            String expectedBuildEncodedValue;
+
+            Builder expectNoEncoding() {
+                this.expectedNeedsToBeEncoded = false;
+                this.expectedGetRawFileName = null;
+                this.expectedBuildEncodedValue = null;
+                return this;
+            }
+
+            Builder expect(String getRawFileName, String buildEncodedValue) {
+                this.expectedNeedsToBeEncoded = true;
+                this.expectedGetRawFileName = getRawFileName;
+                this.expectedBuildEncodedValue = buildEncodedValue;
+                return this;
+            }
+
+            void addTo(List<Fixture> fixtures, String testCaseName) {
+                fixtures.add(new Fixture(testCaseName, rawValue, expectedNeedsToBeEncoded,
+                        expectedGetRawFileName, expectedBuildEncodedValue));
+            }
         }
     }
 }

--- a/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
+++ b/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -22,6 +23,7 @@ import nablarch.fw.web.HttpResponse;
  * @author Taichi Uragami
  *
  */
+@Ignore("要望対応後の検証のためにテストケースを修正。プロダクションコード修正後に@Ignoreを外す。")
 @RunWith(Parameterized.class)
 public class ContentDispositionRawValueTest {
 
@@ -60,16 +62,19 @@ public class ContentDispositionRawValueTest {
         List<Fixture> fixtures = new ArrayList<Fixture>();
 
         fixtures.add(new Fixture("attachment; filename=\"ファイル名.txt\"",
-                true, "ファイル名.txt", "attachment; filename=\"エンコード済み.txt\""));
+                true, "ファイル名.txt",
+                "attachment; filename*=UTF-8''%E3%82%A8%E3%83%B3%E3%82%B3%E3%83%BC%E3%83%89%E6%B8%88%E3%81%BF.txt; filename=\"エンコード済み.txt\""));
 
         fixtures.add(new Fixture("inline; filename=\"ファイル名.txt\"",
-                true, "ファイル名.txt", "inline; filename=\"エンコード済み.txt\""));
+                true, "ファイル名.txt",
+                "inline; filename*=UTF-8''%E3%82%A8%E3%83%B3%E3%82%B3%E3%83%BC%E3%83%89%E6%B8%88%E3%81%BF.txt; filename=\"エンコード済み.txt\""));
 
         fixtures.add(new Fixture("attachment; filename=hoge.txt",
                 false, nothing, nothing));
 
         fixtures.add(new Fixture("attachment; filename=\"hoge.txt\"",
-                true, "hoge.txt", "attachment; filename=\"エンコード済み.txt\""));
+                true, "hoge.txt",
+                "attachment; filename*=UTF-8''%E3%82%A8%E3%83%B3%E3%82%B3%E3%83%BC%E3%83%89%E6%B8%88%E3%81%BF.txt; filename=\"エンコード済み.txt\""));
 
         fixtures.add(new Fixture("attachment",
                 false, nothing, nothing));

--- a/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
+++ b/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
@@ -1,0 +1,114 @@
+package nablarch.fw.web.handler;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * {@link ContentDispositionRawValue}のテスト。
+ * 
+ * @author Taichi Uragami
+ *
+ */
+@RunWith(Parameterized.class)
+public class ContentDispositionRawValueTest {
+
+    @Parameter(0)
+    public Fixture fixture;
+
+    private ContentDispositionRawValue sut;
+
+    @Before
+    public void setUp() {
+        sut = new ContentDispositionRawValue(fixture.rawValue);
+    }
+
+    @Test
+    public void needsToBeEncoded() {
+        assertThat(sut.needsToBeEncoded(), is(fixture.expectedNeedsToBeEncoded));
+    }
+
+    @Test
+    public void getRawFileName() {
+        Assume.assumeTrue(fixture.rawValue + " はエンコード不要", sut.needsToBeEncoded());
+        assertThat(sut.getRawFileName(), is(fixture.expectedGetRawFileName));
+    }
+
+    @Test
+    public void buildEncodedValue() {
+        Assume.assumeTrue(fixture.rawValue + " はエンコード不要", sut.needsToBeEncoded());
+        assertThat(sut.buildEncodedValue("エンコード済み.txt"), is(fixture.expectedBuildEncodedValue));
+    }
+
+    @Parameters(name = "{0}")
+    public static List<Fixture> parameters() {
+
+        String nothing = null;
+
+        List<Fixture> fixtures = new ArrayList<Fixture>();
+
+        fixtures.add(new Fixture("attachment; filename=\"ファイル名.txt\"",
+                true, "ファイル名.txt", "attachment; filename=\"エンコード済み.txt\""));
+
+        fixtures.add(new Fixture("inline; filename=\"ファイル名.txt\"",
+                true, "ファイル名.txt", "inline; filename=\"エンコード済み.txt\""));
+
+        fixtures.add(new Fixture("attachment; filename=hoge.txt",
+                false, nothing, nothing));
+
+        fixtures.add(new Fixture("attachment; filename=\"hoge.txt\"",
+                true, "hoge.txt", "attachment; filename=\"エンコード済み.txt\""));
+
+        fixtures.add(new Fixture("attachment",
+                false, nothing, nothing));
+
+        return fixtures;
+    }
+
+    private static class Fixture {
+
+        /**
+         * Content-Dispositionの値（ただしfilenameはエンコードしていない）。
+         * 
+         * <p>
+         * {@link HttpResponse#setContentDisposition(String, boolean)}で設定される値を想定。
+         * </p>
+         */
+        final String rawValue;
+
+        /** {@link ContentDispositionRawValue#needsToBeEncoded()}の期待値 */
+        final boolean expectedNeedsToBeEncoded;
+        /** {@link ContentDispositionRawValue#getRawFileName()}の期待値 */
+        final String expectedGetRawFileName;
+        /** {@link ContentDispositionRawValue#buildEncodedValue(String)}の期待値 */
+        final String expectedBuildEncodedValue;
+
+        public Fixture(String rawValue, boolean expectedNeedsToBeEncoded,
+                String expectedGetRawFileName, String expectedBuildEncodedValue) {
+            this.rawValue = rawValue;
+            this.expectedNeedsToBeEncoded = expectedNeedsToBeEncoded;
+            this.expectedGetRawFileName = expectedGetRawFileName;
+            this.expectedBuildEncodedValue = expectedBuildEncodedValue;
+        }
+
+        /**
+         * テストケースの名前。
+         */
+        @Override
+        public String toString() {
+            return rawValue;
+        }
+    }
+}

--- a/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
+++ b/src/test/java/nablarch/fw/web/handler/ContentDispositionRawValueTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -23,7 +22,6 @@ import nablarch.fw.web.HttpResponse;
  * @author Taichi Uragami
  *
  */
-@Ignore("要望対応後の検証のためにテストケースを修正。プロダクションコード修正後に@Ignoreを外す。")
 @RunWith(Parameterized.class)
 public class ContentDispositionRawValueTest {
 

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -10,7 +10,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -830,10 +831,11 @@ public class HttpResponseHandlerTest {
                 new MockHttpRequest("GET /test1 HTTP/1.1"), null
         );
         
-        String dispositionTemplate = "attachment; filename=\"%s\"";
+        String dispositionTemplate = "attachment; filename*=UTF-8''%1$s; filename=\"%2$s\"";
         
         String disposition = String.format(
             dispositionTemplate
+          , new UrlDownloadFileNameEncoder().encode("データファイル１")
           , new UrlDownloadFileNameEncoder().encode("データファイル１")
         );
         
@@ -850,6 +852,7 @@ public class HttpResponseHandlerTest {
         );
         disposition = String.format(
             dispositionTemplate
+          , new UrlDownloadFileNameEncoder().encode("データファイル１")
           , new MimeBDownloadFileNameEncoder().encode("データファイル１")
         );
             
@@ -865,6 +868,7 @@ public class HttpResponseHandlerTest {
         );
         disposition = String.format(
             dispositionTemplate
+          , new UrlDownloadFileNameEncoder().encode("データファイル１")
           , new UrlDownloadFileNameEncoder().encode("データファイル１")
         );
             


### PR DESCRIPTION
既存コードでは`HttpResponse`が保持する`Content-Disposition`の値はファイル名がエンコードされておらず、`HttpResponseHandler.replaceContentDisposition`でエンコードしていました。
このエンコードのタイミングで`filename*`パラメーターを追加するように修正しました。

なお、この機能追加をするにあたって`HttpResponse.setContentDisposition`を修正するという対応も考えましたが、
`HttpResponse.getContentDisposition`の仕様が変わってしまい、これを使用している`HttpServer.getFileByContentDisposition`も修正しないといけないなど影響範囲が大きいと思い、`HttpResponseHandler.replaceContentDisposition`を修正することにしました。