### PR TITLE
エラーメッセージをテンプレートエンジンで扱いやすくする対応をしました

### DIFF
--- a/src/main/java/nablarch/common/web/WebConfig.java
+++ b/src/main/java/nablarch/common/web/WebConfig.java
@@ -20,6 +20,9 @@ public class WebConfig {
     private String doubleSubmissionTokenSessionAttributeName = "/" + ExecutionContext.FW_PREFIX
             + "session_token";
 
+    /** エラーメッセージをリクエストスコープに格納する際に使用するキー */
+    private String errorMessageRequestAttributeName = "errors";
+
     /**
      * 二重サブミット防止トークンをHTMLに埋め込む際にinput要素のname属性に設定する名前を取得する。
      * @return 二重サブミット防止トークンをHTMLに埋め込む際にinput要素のname属性に設定する名前
@@ -68,5 +71,23 @@ public class WebConfig {
     public void setDoubleSubmissionTokenSessionAttributeName(
             String doubleSubmissionTokenSessionAttributeName) {
         this.doubleSubmissionTokenSessionAttributeName = doubleSubmissionTokenSessionAttributeName;
+    }
+
+    /**
+     * エラーメッセージをリクエストスコープに格納する際に使用するキーを取得する。
+     *
+     * @return エラーメッセージをリクエストスコープに格納する際に使用するキー
+     */
+    public String getErrorMessageRequestAttributeName() {
+        return errorMessageRequestAttributeName;
+    }
+
+    /**
+     * エラーメッセージをリクエストスコープに格納する際に使用するキーを設定する。
+     *
+     * @param errorMessageRequestAttributeName エラーメッセージをリクエストスコープに格納する際に使用するキー
+     */
+    public void setErrorMessageRequestAttributeName(final String errorMessageRequestAttributeName) {
+        this.errorMessageRequestAttributeName = errorMessageRequestAttributeName;
     }
 }

--- a/src/main/java/nablarch/fw/web/message/ErrorMessages.java
+++ b/src/main/java/nablarch/fw/web/message/ErrorMessages.java
@@ -1,0 +1,151 @@
+package nablarch.fw.web.message;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import nablarch.core.message.ApplicationException;
+import nablarch.core.message.Message;
+import nablarch.core.validation.ValidationResultMessage;
+
+/**
+ * エラーメッセージを保持するクラス。
+ *
+ * @author Hisaaki Sioiri
+ */
+public class ErrorMessages {
+
+    /** 全てのメッセージのリスト */
+    private final List<String> allMessages = new ArrayList<String>();
+
+    /** グローバルなメッセージのリスト */
+    private final List<String> globalMessages = new ArrayList<String>();
+
+    /** propertyに対応したメッセージのリスト **/
+    private final PropertyMessages propertyMessage = new PropertyMessages();
+
+
+    /**
+     * /**
+     * {@link ApplicationException}からオブジェクトを構築する。
+     *
+     * @param applicationException エラーメッセージを持つアプリケーション例外
+     */
+    public ErrorMessages(final ApplicationException applicationException) {
+        for (final Message message : applicationException.getMessages()) {
+            final String messageText = message.formatMessage();
+
+            // 全てのメッセージ
+            allMessages.add(messageText);
+
+            if (message instanceof ValidationResultMessage) {
+                // プロパティに紐づくメッセージ
+                propertyMessage.addMessage(((ValidationResultMessage) message).getPropertyName(), messageText);
+            } else {
+                // プロパティに紐付かないグローバルなメッセージ
+                globalMessages.add(messageText);
+            }
+        }
+    }
+
+    /**
+     * プロパティ名に対応したメッセージを返す。
+     * <p>
+     * プロパティ名に対応したメッセージが存在しない場合は、{@code null}を返す。
+     *
+     * @param propertyName プロパティ名
+     * @return プロパティ名に対応したメッセージ(存在しない場合はr @ code null })
+     */
+    public String getMessage(final String propertyName) {
+        verifyPropertyName(propertyName);
+        return propertyMessage.getMessage(propertyName);
+    }
+
+    /**
+     * 指定されたプロパティ名に対応したエラーがあるかを返す。
+     *
+     * @param propertyName プロパティ名
+     * @return プロパティ名に対応したエラーがある場合は{@code true}
+     */
+    public boolean hasError(final String propertyName) {
+        verifyPropertyName(propertyName);
+        return propertyMessage.messageIndex.containsKey(propertyName);
+    }
+
+    /**
+     * プロパティ名の検証を行う。
+     * <p>
+     * プロパティ名が{@code null}の場合は、{@link IllegalArgumentException}を送出する。
+     *
+     * @param propertyName プロパティ名
+     */
+    private void verifyPropertyName(final String propertyName) {
+        if (propertyName == null) {
+            throw new IllegalArgumentException("propertyName is null.");
+        }
+    }
+
+    /**
+     * プロパティに紐づくメッセージをすべて返す。
+     *
+     * @return プロパティ紐づくメッセージのリスト
+     */
+    public List<String> getPropertyMessages() {
+        return Collections.unmodifiableList(propertyMessage.messages);
+    }
+
+    /**
+     * グローバルなメッセージ(プロパティに紐付かないメッセージ)をすべて返す。
+     *
+     * @return グローバルなメッセージのリスト
+     */
+    public List<String> getGlobalMessages() {
+        return Collections.unmodifiableList(globalMessages);
+    }
+
+    /**
+     * 全てのメッセージを返す。
+     *
+     * @return 全てのメッセージのリスト
+     */
+    public List<String> getAllMessages() {
+        return Collections.unmodifiableList(allMessages);
+    }
+
+    /**
+     * プロパティに紐づくメッセージを保持するクラス。
+     */
+    private static class PropertyMessages {
+
+        /** メッセージのリスト */
+        private final List<String> messages = new ArrayList<String>();
+
+        /** プロパティ名とメッセージ */
+        private final Map<String, Integer> messageIndex = new HashMap<String, Integer>();
+
+        /**
+         * プロパティ名に対応したメッセージを追加する。
+         *
+         * @param propertyName プロパティ名
+         * @param messageText メッセージテキスト
+         */
+        private void addMessage(final String propertyName, final String messageText) {
+            messages.add(messageText);
+            messageIndex.put(propertyName, messages.size() - 1);
+        }
+
+        /**
+         * プロパティ名に対応したメッセージを返す。
+         *
+         * @param propertyName プロパティ名
+         * @return プロパティ名に対応したメッセージ
+         */
+        private String getMessage(final String propertyName) {
+            final Integer index = messageIndex.get(propertyName);
+            return index != null ? messages.get(index) : null;
+        }
+    }
+
+}

--- a/src/main/java/nablarch/fw/web/message/ErrorMessages.java
+++ b/src/main/java/nablarch/fw/web/message/ErrorMessages.java
@@ -24,7 +24,7 @@ public class ErrorMessages {
     private final List<String> globalMessages = new ArrayList<String>();
 
     /** propertyに対応したメッセージのリスト **/
-    private final PropertyMessages propertyMessage = new PropertyMessages();
+    private final PropertyMessages propertyMessages = new PropertyMessages();
 
 
     /**
@@ -42,7 +42,7 @@ public class ErrorMessages {
 
             if (message instanceof ValidationResultMessage) {
                 // プロパティに紐づくメッセージ
-                propertyMessage.addMessage(((ValidationResultMessage) message).getPropertyName(), messageText);
+                propertyMessages.addMessage(((ValidationResultMessage) message).getPropertyName(), messageText);
             } else {
                 // プロパティに紐付かないグローバルなメッセージ
                 globalMessages.add(messageText);
@@ -61,7 +61,7 @@ public class ErrorMessages {
      */
     public String getMessage(final String propertyName) {
         verifyPropertyName(propertyName);
-        return propertyMessage.getMessage(propertyName);
+        return propertyMessages.getMessage(propertyName);
     }
 
     /**
@@ -72,7 +72,7 @@ public class ErrorMessages {
      */
     public boolean hasError(final String propertyName) {
         verifyPropertyName(propertyName);
-        return propertyMessage.messageIndex.containsKey(propertyName);
+        return propertyMessages.messageIndex.containsKey(propertyName);
     }
 
     /**
@@ -94,7 +94,7 @@ public class ErrorMessages {
      * @return プロパティ対応したメッセージのリスト
      */
     public List<String> getPropertyMessages() {
-        return Collections.unmodifiableList(propertyMessage.messages);
+        return Collections.unmodifiableList(propertyMessages.messages);
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/message/ErrorMessages.java
+++ b/src/main/java/nablarch/fw/web/message/ErrorMessages.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import nablarch.core.message.ApplicationException;
 import nablarch.core.message.Message;

--- a/src/main/java/nablarch/fw/web/message/ErrorMessages.java
+++ b/src/main/java/nablarch/fw/web/message/ErrorMessages.java
@@ -23,7 +23,7 @@ public class ErrorMessages {
     /** グローバルなメッセージのリスト */
     private final List<String> globalMessages = new ArrayList<String>();
 
-    /** propertyに対応したメッセージのリスト **/
+    /** プロパティ名に紐づくメッセージを保持するオブジェクト **/
     private final PropertyMessages propertyMessages = new PropertyMessages();
 
     /**

--- a/src/main/java/nablarch/fw/web/message/ErrorMessages.java
+++ b/src/main/java/nablarch/fw/web/message/ErrorMessages.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import nablarch.core.message.ApplicationException;
 import nablarch.core.message.Message;
@@ -53,6 +54,7 @@ public class ErrorMessages {
     /**
      * プロパティ名に対応したメッセージを返す。
      * <p>
+     * プロパティ名に対応したメッセージが複数存在した場合には、最後に追加されたものを返す。
      * プロパティ名に対応したメッセージが存在しない場合は、{@code null}を返す。
      *
      * @param propertyName プロパティ名
@@ -88,9 +90,9 @@ public class ErrorMessages {
     }
 
     /**
-     * プロパティに紐づくメッセージをすべて返す。
+     * プロパティに対応したメッセージをすべて返す。
      *
-     * @return プロパティ紐づくメッセージのリスト
+     * @return プロパティ対応したメッセージのリスト
      */
     public List<String> getPropertyMessages() {
         return Collections.unmodifiableList(propertyMessage.messages);

--- a/src/main/java/nablarch/fw/web/message/ErrorMessages.java
+++ b/src/main/java/nablarch/fw/web/message/ErrorMessages.java
@@ -26,7 +26,6 @@ public class ErrorMessages {
     /** propertyに対応したメッセージのリスト **/
     private final PropertyMessages propertyMessages = new PropertyMessages();
 
-
     /**
      * /**
      * {@link ApplicationException}からオブジェクトを構築する。
@@ -72,7 +71,7 @@ public class ErrorMessages {
      */
     public boolean hasError(final String propertyName) {
         verifyPropertyName(propertyName);
-        return propertyMessages.messageIndex.containsKey(propertyName);
+        return propertyMessages.contains(propertyName);
     }
 
     /**
@@ -147,6 +146,17 @@ public class ErrorMessages {
             final Integer index = messageIndex.get(propertyName);
             return index != null ? messages.get(index) : null;
         }
+
+        /**
+         * プロパティ名に対応したメッセージを含むかどうかを判定する。
+         *
+         * @param propertyName プロパティ名
+         * @return 指定されたプロパティ名を含む場合{@code true}
+         */
+        private boolean contains(final String propertyName) {
+            return messageIndex.containsKey(propertyName);
+        }
+        
     }
 
 }

--- a/src/main/java/nablarch/fw/web/message/ErrorMessages.java
+++ b/src/main/java/nablarch/fw/web/message/ErrorMessages.java
@@ -57,7 +57,7 @@ public class ErrorMessages {
      * プロパティ名に対応したメッセージが存在しない場合は、{@code null}を返す。
      *
      * @param propertyName プロパティ名
-     * @return プロパティ名に対応したメッセージ(存在しない場合はr @ code null })
+     * @return プロパティ名に対応したメッセージ(存在しない場合は{@code null})
      */
     public String getMessage(final String propertyName) {
         verifyPropertyName(propertyName);

--- a/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
+++ b/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
@@ -99,6 +99,5 @@ public class ErrorMessagesTest {
         assertThat(sut.getAllMessages(), Matchers.<String>empty());
         assertThat(sut.getGlobalMessages(), Matchers.<String>empty());
         assertThat(sut.getPropertyMessages(), Matchers.<String>empty());
-        assertThat(sut.hasError("propertyName"), is(false));
     }
 }

--- a/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
+++ b/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 
+import org.hamcrest.Matchers;
+
 import nablarch.core.message.ApplicationException;
 import nablarch.core.message.BasicStringResource;
 import nablarch.core.message.Message;
@@ -88,5 +90,15 @@ public class ErrorMessagesTest {
     public void 全てのメセージが扱えること() {
         assertThat("全てのメッセージが元の順番のまま返されること",
                 sut.getAllMessages(), contains("エラー", "globalメッセージ", "エラー２", "エラー２の２", "globalメッセージ２"));
+    }
+
+    @Test
+    public void メッセージが存在しない場合空のリストが返されること() {
+        final ErrorMessages sut = new ErrorMessages(new ApplicationException());
+
+        assertThat(sut.getAllMessages(), Matchers.<String>empty());
+        assertThat(sut.getGlobalMessages(), Matchers.<String>empty());
+        assertThat(sut.getPropertyMessages(), Matchers.<String>empty());
+        assertThat(sut.hasError("propertyName"), is(false));
     }
 }

--- a/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
+++ b/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
@@ -2,6 +2,7 @@ package nablarch.fw.web.message;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
@@ -40,6 +41,9 @@ public class ErrorMessagesTest {
 
         exception.addMessages(new ValidationResultMessage(
                 "prop2", new BasicStringResource("id2", Collections.singletonMap("ja", "エラー２")), new Object[0]));
+        
+        exception.addMessages(new ValidationResultMessage(
+                "prop2", new BasicStringResource("id2", Collections.singletonMap("ja", "エラー２の２")), new Object[0]));
 
         exception.addMessages(new Message(
                 MessageLevel.ERROR, new BasicStringResource("global2", Collections.singletonMap("ja", "globalメッセージ２")), new Object[0]));
@@ -52,11 +56,14 @@ public class ErrorMessagesTest {
 
         assertThat("prop1のエラーはあるのでtrue", sut.hasError("prop1"), is(true));
         assertThat("prop1のメッセージ", sut.getMessage("prop1"), is("エラー"));
+        
+        assertThat("同一のプロパティ名のメッセージが複数あった場合は最後のメッセージが返される",
+                sut.getMessage("prop2"), is("エラー２の２"));
 
         assertThat("prop3のエラーはないのでfalse", sut.hasError("prop3"), is(false));
         assertThat("prop3は存在しないのでメッセージはnull", sut.getMessage("prop3"), is(nullValue()));
 
-        assertThat("プロパティに紐づくメッセージだけが元の順番のまま返されること", sut.getPropertyMessages(), contains("エラー", "エラー２"));
+        assertThat("プロパティに紐づくメッセージだけが元の順番のまま返されること", sut.getPropertyMessages(), contains("エラー", "エラー２", "エラー２の２"));
     }
 
     @Test
@@ -80,6 +87,6 @@ public class ErrorMessagesTest {
     @Test
     public void 全てのメセージが扱えること() {
         assertThat("全てのメッセージが元の順番のまま返されること",
-                sut.getAllMessages(), contains("エラー", "globalメッセージ", "エラー２", "globalメッセージ２"));
+                sut.getAllMessages(), contains("エラー", "globalメッセージ", "エラー２", "エラー２の２", "globalメッセージ２"));
     }
 }

--- a/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
+++ b/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
@@ -2,7 +2,6 @@ package nablarch.fw.web.message;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 import java.util.Collections;

--- a/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
+++ b/src/test/java/nablarch/fw/web/message/ErrorMessagesTest.java
@@ -1,0 +1,85 @@
+package nablarch.fw.web.message;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+
+import nablarch.core.message.ApplicationException;
+import nablarch.core.message.BasicStringResource;
+import nablarch.core.message.Message;
+import nablarch.core.message.MessageLevel;
+import nablarch.core.validation.ValidationResultMessage;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * {@link ErrorMessages}のテストクラス。
+ */
+public class ErrorMessagesTest {
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private ErrorMessages sut;
+
+    @Before
+    public void setUp() {
+
+        // @formatter:off
+        final ApplicationException exception = new ApplicationException();
+        exception.addMessages(new ValidationResultMessage(
+                "prop1", new BasicStringResource("id", Collections.singletonMap("ja", "エラー")), new Object[0]));
+
+        exception.addMessages(new Message(
+                MessageLevel.ERROR, new BasicStringResource("global", Collections.singletonMap("ja", "globalメッセージ")), new Object[0]));
+
+        exception.addMessages(new ValidationResultMessage(
+                "prop2", new BasicStringResource("id2", Collections.singletonMap("ja", "エラー２")), new Object[0]));
+
+        exception.addMessages(new Message(
+                MessageLevel.ERROR, new BasicStringResource("global2", Collections.singletonMap("ja", "globalメッセージ２")), new Object[0]));
+        sut = new ErrorMessages(exception);
+        // @formatter:on
+    }
+
+    @Test
+    public void プロパティに紐づくメッセージが扱えること() {
+
+        assertThat("prop1のエラーはあるのでtrue", sut.hasError("prop1"), is(true));
+        assertThat("prop1のメッセージ", sut.getMessage("prop1"), is("エラー"));
+
+        assertThat("prop3のエラーはないのでfalse", sut.hasError("prop3"), is(false));
+        assertThat("prop3は存在しないのでメッセージはnull", sut.getMessage("prop3"), is(nullValue()));
+
+        assertThat("プロパティに紐づくメッセージだけが元の順番のまま返されること", sut.getPropertyMessages(), contains("エラー", "エラー２"));
+    }
+
+    @Test
+    public void hasErrorでプロパティ名にnullを指定した場合は例外が送出されること() {
+        expectedException.expect(IllegalArgumentException.class);
+        sut.hasError(null);
+    }
+
+    @Test
+    public void getMessageでプロパティ名にnullを指定した場合は例外が送出されること() {
+        expectedException.expect(IllegalArgumentException.class);
+        sut.getMessage(null);
+    }
+
+    @Test
+    public void グローバルメッセージが扱えること() {
+        assertThat("グローバルメッセージだけが元の順番のまま返されること",
+                sut.getGlobalMessages(), contains("globalメッセージ", "globalメッセージ２"));
+    }
+
+    @Test
+    public void 全てのメセージが扱えること() {
+        assertThat("全てのメッセージが元の順番のまま返されること",
+                sut.getAllMessages(), contains("エラー", "globalメッセージ", "エラー２", "globalメッセージ２"));
+    }
+}


### PR DESCRIPTION
エラーメッセージ(ApplicationException)をメッセージを持つオブジェクトに変換しリクエストスコープに設定しています。
後方互換維持のため、既存のApplicationExceptionを保持する部分には手を入れていません。

リクエストスコープの変数名がかぶってしまった場合のことを考え、WebConfigで設定できるようにしています。