### PR TITLE
言語とタイムゾーンをクッキーに保持する場合にServlet APIがサポートしていればクッキーにhttpOnly属性を設定するように変更

### DIFF
--- a/src/main/java/nablarch/common/web/handler/threadcontext/CookieSupport.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/CookieSupport.java
@@ -4,6 +4,7 @@ import javax.servlet.http.Cookie;
 
 import nablarch.core.util.StringUtil;
 import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpCookie;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
@@ -26,6 +27,9 @@ public class CookieSupport {
 
     /** secure属性の有無（デフォルト無し）*/
     private boolean secure = false;
+
+    /** httpOnly属性の有無（デフォルトあり） */
+    private boolean httpOnly = true;
 
     /**
      * コンストラクタ。
@@ -75,7 +79,16 @@ public class CookieSupport {
     public void setCookieSecure(boolean secure) {
         this.secure = secure;
     }
-    
+
+    /**
+     * 保持するクッキーのhttpOnly属性有無を指定する。
+     * （デフォルトではサポートしていればhttpOnly属性を設定する）
+     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
+     */
+    public void setCookieHttpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
+    }
+
     /**
      * 指定された値をクッキーに設定するための{@link Cookie}を作成する。
      * <p/>
@@ -85,25 +98,29 @@ public class CookieSupport {
      * @return {@link Cookie}
      */
     public Cookie createCookie(ServletExecutionContext ctx, String value) {
-        Cookie cookie = new Cookie(cookieName, value);
+        HttpCookie httpCookie = new HttpCookie();
+        httpCookie.put(cookieName, value);
         if (cookiePath != null) {
-            cookie.setPath(cookiePath);
+            httpCookie.setPath(cookiePath);
         } else {
             String contextPath = ctx.getServletRequest().getContextPath();
             if (StringUtil.isNullOrEmpty(contextPath)) {
                 contextPath = "/";
             }
-            cookie.setPath(contextPath);
+            httpCookie.setPath(contextPath);
         }
         if (cookieDomain != null) {
-            cookie.setDomain(cookieDomain);
+            httpCookie.setDomain(cookieDomain);
         }
         if (cookieMaxAge != null) {
-            cookie.setMaxAge(cookieMaxAge);
+            httpCookie.setMaxAge(cookieMaxAge);
         }
-        cookie.setSecure(secure);
+        httpCookie.setSecure(secure);
+        if (httpCookie.supportsHttpOnly()) {
+            httpCookie.setHttpOnly(httpOnly);
+        }
 
-        return cookie;
+        return httpCookie.convertServletCookies().get(0);
     }
     
     /**

--- a/src/main/java/nablarch/common/web/handler/threadcontext/CookieSupport.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/CookieSupport.java
@@ -10,7 +10,7 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 /**
  * クッキーに対するアクセスをサポートするクラス。
  *
- * Servlet APIがサポートしていれば、クッキーにhttpOnly属性を設定する。
+ * クッキーのhttpOnly属性はアプリケーションで使用しているServlet APIがサポートしている場合のみ設定する。
  *
  * @author Kiyohito Itoh
  */
@@ -30,6 +30,9 @@ public class CookieSupport {
 
     /** secure属性の有無（デフォルト無し）*/
     private boolean secure = false;
+
+    /** httpOnly属性の有無（デフォルトあり） */
+    private boolean httpOnly = true;
 
     /**
      * コンストラクタ。
@@ -81,6 +84,15 @@ public class CookieSupport {
     }
 
     /**
+     * 保持するクッキーのhttpOnly属性有無を指定する。
+     * （デフォルトではサポートしていればhttpOnly属性を設定する）
+     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
+     */
+    public void setCookieHttpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
+    }
+
+    /**
      * 指定された値をクッキーに設定するための{@link Cookie}を作成する。
      * <p/>
      * クッキーのパス階層が指定されていない場合はコンテキストパスをパス階層に指定する。
@@ -108,7 +120,7 @@ public class CookieSupport {
         }
         httpCookie.setSecure(secure);
         if (httpCookie.supportsHttpOnly()) {
-            httpCookie.setHttpOnly(true);
+            httpCookie.setHttpOnly(httpOnly);
         }
 
         return httpCookie.convertServletCookies().get(0);

--- a/src/main/java/nablarch/common/web/handler/threadcontext/CookieSupport.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/CookieSupport.java
@@ -9,6 +9,9 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
  * クッキーに対するアクセスをサポートするクラス。
+ *
+ * Servlet APIがサポートしていれば、クッキーにhttpOnly属性を設定する。
+ *
  * @author Kiyohito Itoh
  */
 public class CookieSupport {
@@ -27,9 +30,6 @@ public class CookieSupport {
 
     /** secure属性の有無（デフォルト無し）*/
     private boolean secure = false;
-
-    /** httpOnly属性の有無（デフォルトあり） */
-    private boolean httpOnly = true;
 
     /**
      * コンストラクタ。
@@ -81,15 +81,6 @@ public class CookieSupport {
     }
 
     /**
-     * 保持するクッキーのhttpOnly属性有無を指定する。
-     * （デフォルトではサポートしていればhttpOnly属性を設定する）
-     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
-     */
-    public void setCookieHttpOnly(boolean httpOnly) {
-        this.httpOnly = httpOnly;
-    }
-
-    /**
      * 指定された値をクッキーに設定するための{@link Cookie}を作成する。
      * <p/>
      * クッキーのパス階層が指定されていない場合はコンテキストパスをパス階層に指定する。
@@ -117,7 +108,7 @@ public class CookieSupport {
         }
         httpCookie.setSecure(secure);
         if (httpCookie.supportsHttpOnly()) {
-            httpCookie.setHttpOnly(httpOnly);
+            httpCookie.setHttpOnly(true);
         }
 
         return httpCookie.convertServletCookies().get(0);

--- a/src/main/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookie.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookie.java
@@ -9,6 +9,9 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
  * クッキーを使用して言語の保持を行うクラス。
+ *
+ * Servlet APIがサポートしていれば、クッキーにhttpOnly属性を設定する。
+ *
  * @author Kiyohito Itoh
  */
 @Published(tag = "architect")
@@ -56,15 +59,6 @@ public class LanguageAttributeInHttpCookie extends LanguageAttributeInHttpSuppor
      */
     public void setCookieSecure(boolean secure) {
         cookieSupport.setCookieSecure(secure);
-    }
-
-    /**
-     * 保持するクッキーのhttpOnly属性有無を指定する。
-     * （デフォルトではサポートしていればhttpOnly属性を設定する）
-     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
-     */
-    public void setCookieHttpOnly(boolean httpOnly) {
-        cookieSupport.setCookieHttpOnly(httpOnly);
     }
 
     @Override

--- a/src/main/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookie.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookie.java
@@ -58,6 +58,15 @@ public class LanguageAttributeInHttpCookie extends LanguageAttributeInHttpSuppor
         cookieSupport.setCookieSecure(secure);
     }
 
+    /**
+     * 保持するクッキーのhttpOnly属性有無を指定する。
+     * （デフォルトではサポートしていればhttpOnly属性を設定する）
+     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
+     */
+    public void setCookieHttpOnly(boolean httpOnly) {
+        cookieSupport.setCookieHttpOnly(httpOnly);
+    }
+
     @Override
     protected void keepLanguage(HttpRequest req, ServletExecutionContext ctx, String language) {
         Cookie cookie = cookieSupport.createCookie(ctx, language);

--- a/src/main/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookie.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookie.java
@@ -10,7 +10,7 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 /**
  * クッキーを使用して言語の保持を行うクラス。
  *
- * Servlet APIがサポートしていれば、クッキーにhttpOnly属性を設定する。
+ * クッキーのhttpOnly属性はアプリケーションで使用しているServlet APIがサポートしている場合のみ設定する。
  *
  * @author Kiyohito Itoh
  */
@@ -59,6 +59,15 @@ public class LanguageAttributeInHttpCookie extends LanguageAttributeInHttpSuppor
      */
     public void setCookieSecure(boolean secure) {
         cookieSupport.setCookieSecure(secure);
+    }
+
+    /**
+     * 保持するクッキーのhttpOnly属性有無を指定する。
+     * （デフォルトではサポートしていればhttpOnly属性を設定する）
+     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
+     */
+    public void setCookieHttpOnly(boolean httpOnly) {
+        cookieSupport.setCookieHttpOnly(httpOnly);
     }
 
     @Override

--- a/src/main/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookie.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookie.java
@@ -10,7 +10,7 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 /**
  * クッキーを使用してタイムゾーンの保持を行うクラス。
  *
- * Servlet APIがサポートしていれば、クッキーにhttpOnly属性を設定する。
+ * クッキーのhttpOnly属性はアプリケーションで使用しているServlet APIがサポートしている場合のみ設定する。
  *
  * @author Kiyohito Itoh
  */
@@ -60,6 +60,15 @@ public class TimeZoneAttributeInHttpCookie extends TimeZoneAttributeInHttpSuppor
      */
     public void setCookieSecure(boolean secure) {
         cookieSupport.setCookieSecure(secure);
+    }
+
+    /**
+     * 保持するクッキーのhttpOnly属性有無を指定する。
+     * （デフォルトではサポートしていればhttpOnly属性を設定する）
+     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
+     */
+    public void setCookieHttpOnly(boolean httpOnly) {
+        cookieSupport.setCookieHttpOnly(httpOnly);
     }
 
     @Override

--- a/src/main/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookie.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookie.java
@@ -9,6 +9,9 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
  * クッキーを使用してタイムゾーンの保持を行うクラス。
+ *
+ * Servlet APIがサポートしていれば、クッキーにhttpOnly属性を設定する。
+ *
  * @author Kiyohito Itoh
  */
 @Published(tag = "architect")
@@ -57,15 +60,6 @@ public class TimeZoneAttributeInHttpCookie extends TimeZoneAttributeInHttpSuppor
      */
     public void setCookieSecure(boolean secure) {
         cookieSupport.setCookieSecure(secure);
-    }
-
-    /**
-     * 保持するクッキーのhttpOnly属性有無を指定する。
-     * （デフォルトではサポートしていればhttpOnly属性を設定する）
-     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
-     */
-    public void setCookieHttpOnly(boolean httpOnly) {
-        cookieSupport.setCookieHttpOnly(httpOnly);
     }
 
     @Override

--- a/src/main/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookie.java
+++ b/src/main/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookie.java
@@ -59,6 +59,15 @@ public class TimeZoneAttributeInHttpCookie extends TimeZoneAttributeInHttpSuppor
         cookieSupport.setCookieSecure(secure);
     }
 
+    /**
+     * 保持するクッキーのhttpOnly属性有無を指定する。
+     * （デフォルトではサポートしていればhttpOnly属性を設定する）
+     * @param httpOnly httpOnly属性を設定するか否か（真の場合、httpOnly属性を設定する）
+     */
+    public void setCookieHttpOnly(boolean httpOnly) {
+        cookieSupport.setCookieHttpOnly(httpOnly);
+    }
+
     @Override
     protected void keepTimeZone(HttpRequest req, ServletExecutionContext ctx, String timeZone) {
         Cookie cookie = cookieSupport.createCookie(ctx, timeZone);

--- a/src/test/java/nablarch/common/web/handler/MockHttpSession.java
+++ b/src/test/java/nablarch/common/web/handler/MockHttpSession.java
@@ -1,0 +1,154 @@
+package nablarch.common.web.handler;
+
+import javax.servlet.ServletContext;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
+
+
+/**
+ * @author Kiyohito Itoh
+ */
+public class MockHttpSession implements javax.servlet.http.HttpSession {
+    
+    private String id;
+    private ServletContext servletContext;
+    private int maxInactiveInterval;
+
+    private Map<String, Object> map = new HashMap<String, Object>();
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Object getAttribute(String arg0) {
+        return map.get(arg0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Enumeration getAttributeNames() {
+        return new Vector(map.keySet()).elements();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long getCreationTime() {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long getLastAccessedTime() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int getMaxInactiveInterval() {
+        return maxInactiveInterval;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ServletContext getServletContext() {
+        return servletContext;
+    }
+
+    public void setServletContext(ServletContext servletContext) {
+        this.servletContext = servletContext;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated
+     */
+    public javax.servlet.http.HttpSessionContext getSessionContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated
+     */
+    public Object getValue(String arg0) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated
+     */
+    public String[] getValueNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void invalidate() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isNew() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated
+     */
+    public void putValue(String arg0, Object arg1) {
+        throw new UnsupportedOperationException();
+        
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void removeAttribute(String arg0) {
+        map.remove(arg0);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated
+     */
+    public void removeValue(String arg0) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setAttribute(String arg0, Object arg1) {
+        map.put(arg0, arg1);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setMaxInactiveInterval(int maxInactiveInterval) {
+        this.maxInactiveInterval = maxInactiveInterval;
+    }
+}

--- a/src/test/java/nablarch/common/web/handler/threadcontext/HttpLanguageAttributeTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/HttpLanguageAttributeTest.java
@@ -1,0 +1,173 @@
+package nablarch.common.web.handler.threadcontext;
+
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.MockHttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link HttpLanguageAttribute}のテスト。
+ * @author Kiyohito Itoh
+ */
+public class HttpLanguageAttributeTest {
+    
+    /**
+     * Accept-Languageヘッダから言語を取得するテスト。
+     */
+    @Test
+    public void testGetAcceptLanguage() {
+
+        MockServletRequest servletReq = new MockServletRequest();
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+        ServletExecutionContext ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        
+        HttpLanguageAttribute attribute = new HttpLanguageAttribute();
+        attribute.setDefaultLanguage("es"); // spanish
+        attribute.setSupportedLanguages("en", "it", "ja", "es", "zh"); // Italian(it), Chinese(zh)
+        
+        Locale locale;
+        
+        /********************************************************************************
+        Accept-Languageヘッダが送信されない場合
+        ********************************************************************************/
+        
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+        
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が先頭に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es, ja;q=0.8, en;q=0.7, it;q=0.7, zh;q=0.5");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値なしの言語が返される。", locale.getLanguage(), is("es"));
+        
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が途中に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.7, ja;q=0.8, en, it;q=0.7, zh;q=0.5");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値なしの言語が返される。", locale.getLanguage(), is("en"));
+
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が最後に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.7, ja;q=0.8, en;q=0.7, it;q=0.7, zh");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値なしの言語が返される。", locale.getLanguage(), is("zh"));
+        
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が含まれない、かつ品質値が一番高い言語が先頭に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.9, ja;q=0.8, en;q=0.7, it;q=0.7, zh;q=0.5");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値が一番高い言語が返される。", locale.getLanguage(), is("es"));
+
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が含まれない、かつ品質値が一番高い言語が途中に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.5, ja;q=0.9, en;q=0.7, it;q=0.7, zh;q=0.5");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値が一番高い言語が返される。", locale.getLanguage(), is("ja"));
+
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が含まれない、かつ品質値が一番高い言語が最後に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.5, ja;q=0.8, en;q=0.7, it;q=0.7, zh;q=0.9");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値が一番高い言語が返される。", locale.getLanguage(), is("zh"));
+
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が含まれない、かつ品質値が等しい複数の言語が先頭に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.9, ja;q=0.9, en;q=0.9, it;q=0.7, zh;q=0.5");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値が一番高い先頭の言語が返される。", locale.getLanguage(), is("es"));
+
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が含まれない、かつ品質値が等しい複数の言語が途中に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.5, ja;q=0.9, en;q=0.9, it;q=0.9, zh;q=0.5");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値が一番高い先頭の言語が返される。", locale.getLanguage(), is("ja"));
+
+        /********************************************************************************
+        サポート対象のAccept-Languageヘッダが送信される場合
+        (品質値なしの言語が含まれない、かつ品質値が等しい複数の言語が最後に含まれる)
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.5, ja;q=0.8, en;q=0.9, it;q=0.9, zh;q=0.9");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値が一番高い先頭の言語が返される。", locale.getLanguage(), is("en"));
+        
+        /********************************************************************************
+        サポート対象とサポート対象でないAccept-Languageヘッダが送信される場合
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "fr, ko;q=0.8, ja;q=0.1"); // Korean(ko)
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("サポート対象の言語が返される。", locale.getLanguage(), is("ja"));
+        
+        /********************************************************************************
+        サブタグを含むAccept-Languageヘッダが送信される場合
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "i-cherokee, x-pig-latin, en-US, fr, ko;q=0.8");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("サポート対象の言語が返される。", locale.getLanguage(), is("en"));
+        
+        /********************************************************************************
+        サポート対象でないAccept-Languageヘッダが送信される場合
+        ********************************************************************************/
+        
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "fr, ko;q=0.8");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+
+        /********************************************************************************
+        不正な品質値を含むAccept-Languageヘッダが送信される場合
+        ********************************************************************************/
+
+        ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        ctx.getServletRequest().getHeaderMap().put("Accept-Language", "es;q=0.5, ja;q=0.8, en;q=0.9a, it;q=a0.9, zh;q=0.a9");
+        locale = (Locale) attribute.getValue(req, ctx);
+        assertThat("品質値が一番高い言語が返される。", locale.getLanguage(), is("ja"));
+    }
+}

--- a/src/test/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookieTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpCookieTest.java
@@ -1,0 +1,361 @@
+package nablarch.common.web.handler.threadcontext;
+
+import nablarch.common.handler.threadcontext.ThreadContextHandler;
+import nablarch.core.ThreadContext;
+import nablarch.core.exception.IllegalConfigurationException;
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.repository.di.DiContainer;
+import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.*;
+import nablarch.fw.web.handler.HttpResponseHandler;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.Cookie;
+import java.util.Arrays;
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.containsString;
+
+/**
+ * {@link LanguageAttributeInHttpSupport}および{@link LanguageAttributeInHttpCookie}のテスト。
+ * @author Kiyohito Itoh
+ */
+public class LanguageAttributeInHttpCookieTest {
+
+    private static final String HTTP_SERVER_FACTORY_KEY = "httpServerFactory";
+
+    @BeforeClass
+    public static void setUpClass() {
+        SystemRepository.clear();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        SystemRepository.clear();
+    }
+    
+    @Before
+    public void setUp() {
+        setUpRepository("nablarch/common/web/handler/threadcontext/cookie.xml");
+    }
+
+    private void setUpRepository(String url) {
+        XmlComponentDefinitionLoader loader =
+            new XmlComponentDefinitionLoader(url);
+        DiContainer container = new DiContainer(loader);
+        SystemRepository.load(container);
+    }
+    
+    /**
+     * リクエストパラメータから言語を取得するテスト。
+     */
+    @Test
+    public void
+    testGetLanguageOfUserChoice() {
+        
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+        
+        LanguageAttributeInHttpCookie attribute = SystemRepository.get("languageAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        Locale locale;
+        
+        /********************************************************************************
+        言語パラメータが送信されない場合
+        (paramNameプロパティ指定あり)
+        ********************************************************************************/
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+        
+        /********************************************************************************
+        サポート対象の言語パラメータが送信される場合
+        (paramNameプロパティ指定あり)
+        ********************************************************************************/
+        
+        req = new MockHttpRequest().setParam("paramName_test", "it");
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+        
+        // アクションでの呼び出し
+        LanguageAttributeInHttpUtil.keepLanguage(req, createExecutionContext(servletReq, servletRes, servletCtx, action), "it");
+        locale = ThreadContext.getLanguage();
+        assertThat("パラメータ送信された言語が返される。", locale.getLanguage(), is("it"));
+        Cookie cookie = servletRes.getCookies().get(0);
+        assertThat("パラメータ送信された言語がクッキーに設定される。", cookie.getName(), is("cookieNameTest"));
+        assertThat("パラメータ送信された言語がクッキーに設定される。", cookie.getValue(), is("it"));
+        assertThat("デフォルトではsecure属性は付与されない。", cookie.getSecure(), is(false));
+
+        /********************************************************************************
+        サポート対象でない言語パラメータが送信される場合
+        (paramNameプロパティ指定あり)
+        ********************************************************************************/
+        
+        req = new MockHttpRequest().setParam("paramName_test", "fr"); // French(fr)
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+
+        // アクションでの呼び出し
+        LanguageAttributeInHttpUtil.keepLanguage(req, createExecutionContext(servletReq, servletRes, servletCtx, action), "fr");
+        locale = ThreadContext.getLanguage();
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+    }
+
+    private ServletExecutionContext createExecutionContext(MockServletRequest servletReq,
+                                                           MockServletResponse servletRes,
+                                                           MockServletContext servletCtx,
+                                                           HttpRequestHandler handler) {
+        return (ServletExecutionContext) new ServletExecutionContext(servletReq, servletRes, servletCtx).addHandler(handler);
+    }
+    
+    
+    /**
+     * ユーザが選択した言語を保持するテスト。
+     */
+    @Test
+    public void testKeepLanguage() {
+        
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                LanguageAttributeInHttpUtil.keepLanguage(request, context, request.getParam("paramName_test")[0]);
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        servletReq.setContextPath("/contentPath_test");
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest().setParam("paramName_test", "it");
+
+        LanguageAttributeInHttpCookie attribute = SystemRepository.get("languageAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultLanguage("es"); // spanish
+        attribute.setSupportedLanguages("en", "it", "ja", "es", "zh"); // Italian(it), Chinese(zh)
+        
+        Cookie cookie;
+        
+        /********************************************************************************
+        必須プロパティのみ設定した場合
+        ********************************************************************************/
+        
+        attribute.setCookieName("cookieName_test");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        
+        cookie = servletRes.getCookies().get(0);
+        
+        assertThat("プロパティ指定された名前が設定される。", cookie.getName(), is("cookieName_test"));
+        assertThat("パラメータ送信された言語が設定される。", cookie.getValue(), is("it"));
+        assertThat("デフォルト値が設定される。", cookie.getPath(), is("/contentPath_test"));
+        assertThat("デフォルト値が設定される。", cookie.getMaxAge(), is(-1));
+        assertNull("ドメイン階層は設定されない。", cookie.getDomain());
+        assertThat("デフォルトではsecure属性は付与されない。", cookie.getSecure(), is(false));
+
+        /********************************************************************************
+        アプリのコンテキストパスがブランクの場合
+        ********************************************************************************/
+
+        servletRes = new MockServletResponse();
+        servletReq.setContextPath("");
+
+        attribute.setCookieName("cookieName_test");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+
+        cookie = servletRes.getCookies().get(0);
+
+        assertThat("プロパティ指定された名前が設定される。", cookie.getName(), is("cookieName_test"));
+        assertThat("パラメータ送信された言語が設定される。", cookie.getValue(), is("it"));
+        assertThat("/が設定される。", cookie.getPath(), is("/"));
+        assertThat("デフォルト値が設定される。", cookie.getMaxAge(), is(-1));
+        assertNull("ドメイン階層は設定されない。", cookie.getDomain());
+
+        /********************************************************************************
+        全てのプロパティを設定した場合
+        ********************************************************************************/
+        
+        servletRes = new MockServletResponse();
+        
+        attribute.setCookieName("cookieName_test");
+        attribute.setCookiePath("/aaa/bbb/ccc");
+        attribute.setCookieDomain("xxx.yyy.zzz");
+        attribute.setCookieMaxAge(31104000);
+        attribute.setCookieSecure(true);
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        
+        cookie = servletRes.getCookies().get(0);
+        
+        assertThat("プロパティ指定された名前が設定される。", cookie.getName(), is("cookieName_test"));
+        assertThat("パラメータ送信された言語が設定される。", cookie.getValue(), is("it"));
+        assertThat("プロパティ指定されたパス階層が設定される。", cookie.getPath(), is("/aaa/bbb/ccc"));
+        assertThat("プロパティ指定された最長存続期間(秒単位)が設定される。", cookie.getMaxAge(), is(31104000));
+        assertThat("プロパティ指定されたドメイン階層が設定される。", cookie.getDomain(), is("xxx.yyy.zzz"));
+        assertThat("プロパティ指定されたsecure属性が付与される。", cookie.getSecure(), is(true));
+    }
+    
+    /**
+     * 保持している言語を取得するテスト。
+     */
+    @Test
+    public void testGetKeepingLanguage() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+
+        LanguageAttributeInHttpCookie attribute = SystemRepository.get("languageAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultLanguage("es"); // spanish
+        attribute.setSupportedLanguages("en", "it", "ja", "es", "zh"); // Italian(it), Chinese(zh)
+        attribute.setCookieName("cookieName_test");
+        
+        Locale locale;
+        
+        /********************************************************************************
+        保持していない場合
+        ********************************************************************************/
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+        
+        /********************************************************************************
+        サポート対象の言語を保持している場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        servletReq.setCookies(new Cookie("other", "ja"), new Cookie("cookieName_test", "it"));
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("保持している言語が返される。", locale.getLanguage(), is("it"));
+        
+        /********************************************************************************
+        サポート対象でない言語を保持している場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        servletReq.setCookies(new Cookie("other", "ja"), new Cookie("cookieName_test", "fr"));
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+
+        /********************************************************************************
+        クッキー配列のサイズが0の場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        servletReq.setCookies(new Cookie[0]);
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+    }
+
+    /** Cookieにsecure属性を付与する設定の場合、Cookieにsecure属性が設定されること */
+    @Test
+    public void testSecureCookie() {
+        // セキュア設定のコンポーネント定義を読み込み
+        setUpRepository("nablarch/common/web/handler/threadcontext/cookie_secure.xml");
+        HttpServer server = createServer();
+        HttpResponse res = server.startLocal()
+                                 .handle(new MockHttpRequest("GET / HTTP/1.1"), new ExecutionContext());
+
+        // HttpCookie#valueOf(String)がおかしいのでtoStringしてアサート
+        // Jetty9にてSet-Cookieの各ディレクティブの間に半角スペースが入るようになったため削除してからアサート
+        assertThat("Cookieにsecure属性が付与されていること",
+                   res.toString().replaceAll(" ", ""),
+                   containsString(
+                           "Set-Cookie:nablarch_language=ja;Path=/;Secure"));
+    }
+
+    /** Cookieにsecure属性を付与する設定でない場合、Cookieにsecure属性が設定されないこと */
+    @Test
+    public void testSecureCookieFalse() {
+        HttpServer server = createServer();
+        HttpResponse res = server.startLocal()
+                                 .handle(new MockHttpRequest("GET / HTTP/1.1"), new ExecutionContext());
+        // HttpCookie#valueOf(String)がおかしいのでtoStringしてアサート
+        // Jetty9にてSet-Cookieの各ディレクティブの間に半角スペースが入るようになったため削除してからアサート
+        assertThat(res.toString().replaceAll(" ", ""), containsString(
+                "Set-Cookie:cookieNameTest=ja;Path=/"));
+
+        assertThat("Secure属性が付与されていないこと",
+                   res.toString(),
+                   not(containsString("Secure")));
+    }
+
+
+    /**
+     * {@link HttpServer}を生成する。
+     * @return クッキーの設定を行うHttpServer
+     */
+    private HttpServer createServer() {
+        HttpServerFactory factory = SystemRepository.get(HTTP_SERVER_FACTORY_KEY);
+        if (factory == null) {
+            throw new IllegalConfigurationException("could not find component. name=[" + HTTP_SERVER_FACTORY_KEY + "].");
+        }
+        return factory.create().setHandlerQueue(Arrays.asList(
+                new HttpResponseHandler(),
+                new HttpRequestHandler() {
+                    public HttpResponse handle(HttpRequest req, ExecutionContext ctx) {
+                        // クッキーに設定
+                        LanguageAttributeInHttpUtil.keepLanguage(req, ctx, "ja");
+                        return new HttpResponse(200);
+                    }
+                })
+        );
+    }
+}

--- a/src/test/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpSessionTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpSessionTest.java
@@ -1,0 +1,239 @@
+package nablarch.common.web.handler.threadcontext;
+
+import nablarch.common.handler.threadcontext.ThreadContextHandler;
+import nablarch.common.web.handler.MockHttpSession;
+import nablarch.core.ThreadContext;
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.repository.di.DiContainer;
+import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.MockHttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link LanguageAttributeInHttpSession}のテスト。
+ * @author Kiyohito Itoh
+ */
+public class LanguageAttributeInHttpSessionTest {
+    
+    @Before
+    public void setUp() {
+        XmlComponentDefinitionLoader loader = new XmlComponentDefinitionLoader("nablarch/common/web/handler/threadcontext/session.xml");
+        DiContainer container = new DiContainer(loader);
+        SystemRepository.load(container);
+    }
+    
+    private ServletExecutionContext createExecutionContext(MockServletRequest servletReq,
+                                                           MockServletResponse servletRes,
+                                                           MockServletContext servletCtx,
+                                                           HttpRequestHandler handler) {
+        return (ServletExecutionContext) new ServletExecutionContext(servletReq, servletRes, servletCtx).addHandler(handler);
+    }
+    
+    /**
+     * ユーザが選択した言語を保持するテスト。
+     */
+    @Test
+    public void testKeepLanguage() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                LanguageAttributeInHttpUtil.keepLanguage(request, context, request.getParam("paramName_test")[0]);
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        MockHttpSession session = new MockHttpSession();
+        servletReq.setSession(session);
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest().setParam("paramName_test", "it");
+        
+        LanguageAttributeInHttpSession attribute = SystemRepository.get("languageAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultLanguage("es"); // spanish
+        attribute.setSupportedLanguages("en", "it", "ja", "es", "zh"); // Italian(it), Chinese(zh)
+        
+        ExecutionContext ctx;
+        
+        /********************************************************************************
+        キー名を指定していない場合
+        ********************************************************************************/
+
+        ctx = createExecutionContext(servletReq, servletRes, servletCtx, action);
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, ctx);
+        
+        assertThat("デフォルトのキー名で言語が設定される。", ctx.<Object>getSessionScopedVar(ThreadContext.LANG_KEY).toString(), is("it"));
+        
+        /********************************************************************************
+        キー名を指定した場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        session = new MockHttpSession();
+        servletReq.setSession(session);
+        ctx = createExecutionContext(servletReq, servletRes, servletCtx, action);
+        
+        attribute.setSessionKey("sessionKey_test");
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, ctx);
+        
+        assertNull("デフォルトのキー名で言語が設定されない。", ctx.getSessionScopedVar(ThreadContext.LANG_KEY));
+        assertThat("プロパティ指定されたキー名で言語が設定される。", ctx.<Object>getSessionScopedVar("sessionKey_test").toString(), is("it"));
+    }
+
+    /**
+     * アプリケーションのデータベースなどにユーザに紐付けて言語を永続化しているケースを想定したテスト。
+     */
+    @Test
+    public void testApplicationPersistenceLanguage() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                // 決め打ちでzhを設定する。
+                LanguageAttributeInHttpUtil.keepLanguage(request, context, "zh");
+                return null;
+            }
+        };
+
+        MockServletRequest servletReq = new MockServletRequest();
+        MockHttpSession session = new MockHttpSession();
+        servletReq.setSession(session);
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+
+        LanguageAttributeInHttpSession attribute = SystemRepository.get("languageAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultLanguage("es"); // spanish
+        attribute.setSupportedLanguages("en", "it", "ja", "es", "zh"); // Italian(it), Chinese(zh)
+        
+        Locale locale;
+        
+        /********************************************************************************
+        アプリ側で言語を設定する場合
+        ********************************************************************************/
+
+        ExecutionContext ctx = createExecutionContext(servletReq, servletRes, servletCtx, action);
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, ctx);
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("アプリで設定した言語が返される。", locale.getLanguage(), is("zh"));
+        assertThat("デフォルトのキー名で言語が設定される。", ctx.<Object>getSessionScopedVar(ThreadContext.LANG_KEY).toString(), is("zh"));
+    }
+    
+    /**
+     * 保持している言語を取得するテスト。
+     */
+    @Test
+    public void testGetKeepingLanguage() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                return null;
+            }
+        };
+
+        MockServletRequest servletReq = new MockServletRequest();
+        MockHttpSession session = new MockHttpSession();
+        servletReq.setSession(session);
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+        ServletExecutionContext ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+
+        LanguageAttributeInHttpSession attribute = SystemRepository.get("languageAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultLanguage("es"); // spanish
+        attribute.setSupportedLanguages("en", "it", "ja", "es", "zh"); // Italian(it), Chinese(zh)
+        
+        Locale locale;
+        
+        /********************************************************************************
+        保持していない場合
+        ********************************************************************************/
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+        
+        /********************************************************************************
+        サポート対象の言語を保持している場合
+        (キー名を指定していない)
+        ********************************************************************************/
+        
+        ctx.setSessionScopedVar(ThreadContext.LANG_KEY, "it");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("保持している言語が返される。", locale.getLanguage(), is("it"));
+        
+        /********************************************************************************
+        サポート対象でない言語を保持している場合
+        (キー名を指定していない)
+        ********************************************************************************/
+        
+        ctx.setSessionScopedVar(ThreadContext.LANG_KEY, "fr");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+
+        /********************************************************************************
+        サポート対象の言語を保持している場合
+        (キー名を指定している)
+        ********************************************************************************/
+        
+        attribute.setSessionKey("sessionKey_test");
+        ctx.setSessionScopedVar("sessionKey_test", "ja");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("保持している言語が返される。", locale.getLanguage(), is("ja"));
+        
+        /********************************************************************************
+        サポート対象でない言語を保持している場合
+        (キー名を指定している)
+        ********************************************************************************/
+
+        attribute.setSessionKey("sessionKey_test");
+        ctx.setSessionScopedVar("sessionKey_test", "fr");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        locale = ThreadContext.getLanguage();
+        
+        assertThat("デフォルトの言語が返される。", locale.getLanguage(), is("es"));
+    }
+}

--- a/src/test/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpUtilTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/LanguageAttributeInHttpUtilTest.java
@@ -1,0 +1,53 @@
+package nablarch.common.web.handler.threadcontext;
+
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.repository.di.DiContainer;
+import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.MockHttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * {@link LanguageAttributeInHttpUtil} のテスト。
+ *
+ * @author Koichi Asano 
+ *
+ */
+public class LanguageAttributeInHttpUtilTest {
+    @Before
+    public void setUp() {
+        SystemRepository.clear();
+        XmlComponentDefinitionLoader loader = new XmlComponentDefinitionLoader("nablarch/common/web/handler/threadcontext/no_support.xml");
+        DiContainer container = new DiContainer(loader);
+        SystemRepository.load(container);
+    }
+    
+    /**
+     * サポート用コンポーネントが存在しなかった場合。
+     */
+    @Test
+    public void testNoSupport() {
+        HttpRequest req = new MockHttpRequest();
+        MockServletRequest servletReq = new MockServletRequest();
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        ServletExecutionContext ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+        try {
+            LanguageAttributeInHttpUtil.keepLanguage(req, ctx, "ja");
+            fail("例外が発生するはず。");
+        } catch (RuntimeException e) {
+            assertThat(e, instanceOf(RuntimeException.class));
+            assertThat(e.getMessage(), is("component languageAttribute was not found."));
+        }
+    }
+}

--- a/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookieTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpCookieTest.java
@@ -1,0 +1,360 @@
+package nablarch.common.web.handler.threadcontext;
+
+import nablarch.common.handler.threadcontext.ThreadContextHandler;
+import nablarch.core.ThreadContext;
+import nablarch.core.exception.IllegalConfigurationException;
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.repository.di.DiContainer;
+import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.*;
+import nablarch.fw.web.handler.HttpResponseHandler;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.Cookie;
+import java.util.Arrays;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.containsString;
+
+/**
+ * {@link TimeZoneAttributeInHttpSupport}および{@link TimeZoneAttributeInHttpCookie}のテスト。
+ * @author Kiyohito Itoh
+ */
+public class TimeZoneAttributeInHttpCookieTest {
+
+    private static final String HTTP_SERVER_FACTORY_KEY = "httpServerFactory";
+
+    @BeforeClass
+    public static void setUpClass() {
+        SystemRepository.clear();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        SystemRepository.clear();
+    }
+    
+    @Before
+    public void setUp() {
+        setUpRepository("nablarch/common/web/handler/threadcontext/cookie.xml");
+    }
+
+    private void setUpRepository(String url) {
+        XmlComponentDefinitionLoader loader =
+            new XmlComponentDefinitionLoader(url);
+        DiContainer container = new DiContainer(loader);
+        SystemRepository.load(container);
+    }
+    
+    /**
+     * リクエストパラメータからタイムゾーンを取得するテスト。
+     */
+    @Test
+    public void testGetTimeZoneOfUserChoice() {
+        
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+        
+        TimeZoneAttributeInHttpCookie attribute = SystemRepository.get("timeZoneAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        TimeZone timeZone;
+        
+        /********************************************************************************
+        タイムゾーンパラメータが送信されない場合
+        (paramNameプロパティ指定あり)
+        ********************************************************************************/
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+        
+        /********************************************************************************
+        サポート対象のタイムゾーンパラメータが送信される場合
+        (paramNameプロパティ指定あり)
+        ********************************************************************************/
+        
+        req = new MockHttpRequest().setParam("paramName_test", "Europe/Rome");
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+        
+        // アクションでの呼び出し
+        TimeZoneAttributeInHttpUtil.keepTimeZone(req, createExecutionContext(servletReq, servletRes, servletCtx, action), "Europe/Rome");
+        timeZone = ThreadContext.getTimeZone();
+        assertThat("パラメータ送信されたタイムゾーンが返される。", timeZone.getID(), is("Europe/Rome"));
+        Cookie cookie = servletRes.getCookies().get(0);
+        assertThat("パラメータ送信されたタイムゾーンがクッキーに設定される。", cookie.getName(), is("cookieNameTest"));
+        assertThat("パラメータ送信されたタイムゾーンがクッキーに設定される。", cookie.getValue(), is("Europe/Rome"));
+        assertThat("デフォルトではsecure属性は付与されない。", cookie.getSecure(), is(false));
+        /********************************************************************************
+        サポート対象でないタイムゾーンパラメータが送信される場合
+        (paramNameプロパティ指定あり)
+        ********************************************************************************/
+        
+        req = new MockHttpRequest().setParam("paramName_test", "Europe/London");
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+
+        // アクションでの呼び出し
+        TimeZoneAttributeInHttpUtil.keepTimeZone(req, createExecutionContext(servletReq, servletRes, servletCtx, action), "Europe/London");
+        timeZone = ThreadContext.getTimeZone();
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+    }
+
+    private ServletExecutionContext createExecutionContext(MockServletRequest servletReq,
+                                                           MockServletResponse servletRes,
+                                                           MockServletContext servletCtx,
+                                                           HttpRequestHandler handler) {
+        return (ServletExecutionContext) new ServletExecutionContext(servletReq, servletRes, servletCtx).addHandler(handler);
+    }
+    
+    
+    /**
+     * ユーザが選択したタイムゾーンを保持するテスト。
+     */
+    @Test
+    public void testKeepTimeZone() {
+        
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                TimeZoneAttributeInHttpUtil.keepTimeZone(request, context, request.getParam("paramName_test")[0]);
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        servletReq.setContextPath("/contentPath_test");
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest().setParam("paramName_test", "Europe/Rome");
+
+        TimeZoneAttributeInHttpCookie attribute = SystemRepository.get("timeZoneAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultTimeZone("Europe/Madrid");
+        attribute.setSupportedTimeZones("America/New_York", "Europe/Rome", "Asia/Tokyo", "Europe/Madrid", "Asia/Shanghai");
+        
+        Cookie cookie;
+        
+        /********************************************************************************
+        必須プロパティのみ設定した場合
+        ********************************************************************************/
+        
+        attribute.setCookieName("cookieName_test");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        
+        cookie = servletRes.getCookies().get(0);
+        
+        assertThat("プロパティ指定された名前が設定される。", cookie.getName(), is("cookieName_test"));
+        assertThat("パラメータ送信されたタイムゾーンが設定される。", cookie.getValue(), is("Europe/Rome"));
+        assertThat("デフォルト値が設定される。", cookie.getPath(), is("/contentPath_test"));
+        assertThat("デフォルト値が設定される。", cookie.getMaxAge(), is(-1));
+        assertNull("ドメイン階層は設定されない。", cookie.getDomain());
+        assertThat("デフォルトではsecure属性は付与されない。", cookie.getSecure(), is(false));
+
+        /********************************************************************************
+        アプリのコンテキストパスがブランクの場合
+        ********************************************************************************/
+
+        servletRes = new MockServletResponse();
+        servletReq.setContextPath("");
+
+        attribute.setCookieName("cookieName_test");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+
+        cookie = servletRes.getCookies().get(0);
+
+        assertThat("プロパティ指定された名前が設定される。", cookie.getName(), is("cookieName_test"));
+        assertThat("パラメータ送信されたタイムゾーンが設定される。", cookie.getValue(), is("Europe/Rome"));
+        assertThat("/が設定される。", cookie.getPath(), is("/"));
+        assertThat("デフォルト値が設定される。", cookie.getMaxAge(), is(-1));
+        assertNull("ドメイン階層は設定されない。", cookie.getDomain());
+
+        /********************************************************************************
+        全てのプロパティを設定した場合
+        ********************************************************************************/
+        
+        servletRes = new MockServletResponse();
+        
+        attribute.setCookieName("cookieName_test");
+        attribute.setCookiePath("/aaa/bbb/ccc");
+        attribute.setCookieDomain("xxx.yyy.zzz");
+        attribute.setCookieMaxAge(31104000);
+        attribute.setCookieSecure(true);
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        
+        cookie = servletRes.getCookies().get(0);
+        
+        assertThat("プロパティ指定された名前が設定される。", cookie.getName(), is("cookieName_test"));
+        assertThat("パラメータ送信されたタイムゾーンが設定される。", cookie.getValue(), is("Europe/Rome"));
+        assertThat("プロパティ指定されたパス階層が設定される。", cookie.getPath(), is("/aaa/bbb/ccc"));
+        assertThat("プロパティ指定された最長存続期間(秒単位)が設定される。", cookie.getMaxAge(), is(31104000));
+        assertThat("プロパティ指定されたドメイン階層が設定される。", cookie.getDomain(), is("xxx.yyy.zzz"));
+        assertThat("プロパティ指定されたsecure属性が付与される。", cookie.getSecure(), is(true));
+    }
+    
+    /**
+     * 保持しているタイムゾーンを取得するテスト。
+     */
+    @Test
+    public void testGetKeepingTimeZone() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+
+        TimeZoneAttributeInHttpCookie attribute = SystemRepository.get("timeZoneAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultTimeZone("Europe/Madrid");
+        attribute.setSupportedTimeZones("America/New_York", "Europe/Rome", "Asia/Tokyo", "Europe/Madrid", "Asia/Shangha");
+        attribute.setCookieName("cookieName_test");
+        
+        TimeZone timeZone;
+        
+        /********************************************************************************
+        保持していない場合
+        ********************************************************************************/
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+        
+        /********************************************************************************
+        サポート対象のタイムゾーンを保持している場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        servletReq.setCookies(new Cookie("other", "Asia/Tokyo"), new Cookie("cookieName_test", "Europe/Rome"));
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("保持しているタイムゾーンが返される。", timeZone.getID(), is("Europe/Rome"));
+        
+        /********************************************************************************
+        サポート対象でないタイムゾーンを保持している場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        servletReq.setCookies(new Cookie("other", "Asia/Tokyo"), new Cookie("cookieName_test", "Europe/London"));
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+
+        /********************************************************************************
+        クッキー配列のサイズが0の場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        servletReq.setCookies(new Cookie[0]);
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+    }
+
+    /** Cookieにsecure属性を付与する設定の場合、Cookieにsecure属性が設定されること */
+    @Test
+    public void testSecureCookie() {
+        // セキュア設定のコンポーネント定義を読み込み
+        setUpRepository("nablarch/common/web/handler/threadcontext/cookie_secure.xml");
+        HttpServer server = createServer();
+        HttpResponse res = server.startLocal()
+                                 .handle(new MockHttpRequest("GET / HTTP/1.1"), new ExecutionContext());
+
+        // HttpCookie#valueOf(String)がおかしいのでtoStringしてアサート
+        // Jetty9にてSet-Cookieの各ディレクティブの間に半角スペースが入るようになったため削除してからアサート
+        assertThat("Cookieにsecure属性が付与されていること",
+                   res.toString().replaceAll(" ", ""),
+                   containsString(
+                           "Set-Cookie:nablarch_timeZone=Asia/Tokyo;Path=/;Secure"));
+    }
+
+    /** Cookieにsecure属性を付与する設定でない場合、Cookieにsecure属性が設定されないこと */
+    @Test
+    public void testSecureCookieFalse() {
+        HttpServer server = createServer();
+        HttpResponse res = server.startLocal()
+                                 .handle(new MockHttpRequest("GET / HTTP/1.1"), new ExecutionContext());
+        // HttpCookie#valueOf(String)がおかしいのでtoStringしてアサート
+        // Jetty9にてSet-Cookieの各ディレクティブの間に半角スペースが入るようになったため削除してからアサート
+        assertThat(res.toString().replaceAll(" ", ""), containsString(
+                "Set-Cookie:cookieNameTest=Asia/Tokyo;Path=/"));
+
+        assertThat("Secure属性が付与されていないこと",
+                   res.toString(),
+                   not(containsString("Secure")));
+    }
+
+    /**
+     * {@link HttpServer}を生成する。
+     * @return クッキーの設定を行うHttpServer
+     */
+    private HttpServer createServer() {
+        HttpServerFactory factory = SystemRepository.get(HTTP_SERVER_FACTORY_KEY);
+        if (factory == null) {
+            throw new IllegalConfigurationException("could not find component. name=[" + HTTP_SERVER_FACTORY_KEY + "].");
+        }
+        return factory.create().setHandlerQueue(Arrays.asList(
+                new HttpResponseHandler(),
+                new HttpRequestHandler() {
+                    public HttpResponse handle(HttpRequest req, ExecutionContext ctx) {
+                        // クッキーに設定
+                        TimeZoneAttributeInHttpUtil.keepTimeZone(req, ctx, "Asia/Tokyo");
+                        return new HttpResponse(200);
+                    }
+                })
+        );
+    }
+
+
+}

--- a/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpSessionTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpSessionTest.java
@@ -1,0 +1,239 @@
+package nablarch.common.web.handler.threadcontext;
+
+import nablarch.common.handler.threadcontext.ThreadContextHandler;
+import nablarch.common.web.handler.MockHttpSession;
+import nablarch.core.ThreadContext;
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.repository.di.DiContainer;
+import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.MockHttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link TimeZoneAttributeInHttpSession}のテスト。
+ * @author Kiyohito Itoh
+ */
+public class TimeZoneAttributeInHttpSessionTest {
+    
+    @Before
+    public void setUp() {
+        XmlComponentDefinitionLoader loader = new XmlComponentDefinitionLoader("nablarch/common/web/handler/threadcontext/session.xml");
+        DiContainer container = new DiContainer(loader);
+        SystemRepository.load(container);
+    }
+    
+    private ServletExecutionContext createExecutionContext(MockServletRequest servletReq,
+                                                           MockServletResponse servletRes,
+                                                           MockServletContext servletCtx,
+                                                           HttpRequestHandler handler) {
+        return (ServletExecutionContext) new ServletExecutionContext(servletReq, servletRes, servletCtx).addHandler(handler);
+    }
+    
+    /**
+     * ユーザが選択したタイムゾーンを保持するテスト。
+     */
+    @Test
+    public void testKeepTimeZone() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                TimeZoneAttributeInHttpUtil.keepTimeZone(request, context, request.getParam("paramName_test")[0]);
+                return null;
+            }
+        };
+        
+        MockServletRequest servletReq = new MockServletRequest();
+        MockHttpSession session = new MockHttpSession();
+        servletReq.setSession(session);
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest().setParam("paramName_test", "Europe/Rome");
+        
+        TimeZoneAttributeInHttpSession attribute = SystemRepository.get("timeZoneAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultTimeZone("Europe/Madrid"); // spanish
+        attribute.setSupportedTimeZones("America/New_York", "Europe/Rome", "Asia/Tokyo", "Europe/Madrid", "Asia/Shanghai"); // Italian(it), Chinese(zh)
+        
+        ExecutionContext ctx;
+        
+        /********************************************************************************
+        キー名を指定していない場合
+        ********************************************************************************/
+
+        ctx = createExecutionContext(servletReq, servletRes, servletCtx, action);
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, ctx);
+        
+        assertThat("デフォルトのキー名でタイムゾーンが設定される。", ctx.<Object>getSessionScopedVar(ThreadContext.TIME_ZONE_KEY).toString(), is("Europe/Rome"));
+        
+        /********************************************************************************
+        キー名を指定した場合
+        ********************************************************************************/
+        
+        servletReq = new MockServletRequest();
+        session = new MockHttpSession();
+        servletReq.setSession(session);
+        ctx = createExecutionContext(servletReq, servletRes, servletCtx, action);
+        
+        attribute.setSessionKey("sessionKey_test");
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, ctx);
+        
+        assertNull("デフォルトのキー名でタイムゾーンが設定されない。", ctx.getSessionScopedVar(ThreadContext.TIME_ZONE_KEY));
+        assertThat("プロパティ指定されたキー名でタイムゾーンが設定される。", ctx.<Object>getSessionScopedVar("sessionKey_test").toString(), is("Europe/Rome"));
+    }
+
+    /**
+     * アプリケーションのデータベースなどにユーザに紐付けてタイムゾーンを永続化しているケースを想定したテスト。
+     */
+    @Test
+    public void testApplicationPersistenceTimeZone() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                // 決め打ちでzhを設定する。
+                TimeZoneAttributeInHttpUtil.keepTimeZone(request, context, "Asia/Shanghai");
+                return null;
+            }
+        };
+
+        MockServletRequest servletReq = new MockServletRequest();
+        MockHttpSession session = new MockHttpSession();
+        servletReq.setSession(session);
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+
+        TimeZoneAttributeInHttpSession attribute = SystemRepository.get("timeZoneAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultTimeZone("Europe/Madrid"); // spanish
+        attribute.setSupportedTimeZones("America/New_York", "Europe/Rome", "Asia/Tokyo", "Europe/Madrid", "Asia/Shanghai"); // Italian(it), Chinese(zh)
+        
+        TimeZone timeZone;
+        
+        /********************************************************************************
+        アプリ側でタイムゾーンを設定する場合
+        ********************************************************************************/
+
+        ExecutionContext ctx = createExecutionContext(servletReq, servletRes, servletCtx, action);
+        
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, ctx);
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("アプリで設定したタイムゾーンが返される。", timeZone.getID(), is("Asia/Shanghai"));
+        assertThat("デフォルトのキー名でタイムゾーンが設定される。", ctx.<Object>getSessionScopedVar(ThreadContext.TIME_ZONE_KEY).toString(), is("Asia/Shanghai"));
+    }
+    
+    /**
+     * 保持しているタイムゾーンを取得するテスト。
+     */
+    @Test
+    public void testGetKeepingTimeZone() {
+
+        HttpRequestHandler action = new HttpRequestHandler() {
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                return null;
+            }
+        };
+
+        MockServletRequest servletReq = new MockServletRequest();
+        MockHttpSession session = new MockHttpSession();
+        servletReq.setSession(session);
+        MockServletResponse servletRes = new MockServletResponse();
+        MockServletContext servletCtx = new MockServletContext();
+        HttpRequest req = new MockHttpRequest();
+        ServletExecutionContext ctx = new ServletExecutionContext(servletReq, servletRes, servletCtx);
+
+        TimeZoneAttributeInHttpSession attribute = SystemRepository.get("timeZoneAttribute");
+        ThreadContextHandler handler = new ThreadContextHandler(attribute);
+        
+        attribute.setDefaultTimeZone("Europe/Madrid"); // spanish
+        attribute.setSupportedTimeZones("America/New_York", "Europe/Rome", "Asia/Tokyo", "Europe/Madrid", "Asia/Shanghai"); // Italian(it), Chinese(zh)
+        
+        TimeZone timeZone;
+        
+        /********************************************************************************
+        保持していない場合
+        ********************************************************************************/
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+        
+        /********************************************************************************
+        サポート対象のタイムゾーンを保持している場合
+        (キー名を指定していない)
+        ********************************************************************************/
+        
+        ctx.setSessionScopedVar(ThreadContext.TIME_ZONE_KEY, "Europe/Rome");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("保持しているタイムゾーンが返される。", timeZone.getID(), is("Europe/Rome"));
+        
+        /********************************************************************************
+        サポート対象でないタイムゾーンを保持している場合
+        (キー名を指定していない)
+        ********************************************************************************/
+        
+        ctx.setSessionScopedVar(ThreadContext.TIME_ZONE_KEY, "Europe/London");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+
+        /********************************************************************************
+        サポート対象のタイムゾーンを保持している場合
+        (キー名を指定している)
+        ********************************************************************************/
+        
+        attribute.setSessionKey("sessionKey_test");
+        ctx.setSessionScopedVar("sessionKey_test", "Asia/Tokyo");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("保持しているタイムゾーンが返される。", timeZone.getID(), is("Asia/Tokyo"));
+        
+        /********************************************************************************
+        サポート対象でないタイムゾーンを保持している場合
+        (キー名を指定している)
+        ********************************************************************************/
+
+        attribute.setSessionKey("sessionKey_test");
+        ctx.setSessionScopedVar("sessionKey_test", "Europe/London");
+
+        // ThareadContextHandlerでの呼び出し
+        handler.handle(req, createExecutionContext(servletReq, servletRes, servletCtx, action));
+        timeZone = ThreadContext.getTimeZone();
+        
+        assertThat("デフォルトのタイムゾーンが返される。", timeZone.getID(), is("Europe/Madrid"));
+    }
+}

--- a/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpUtilTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpUtilTest.java
@@ -1,0 +1,141 @@
+package nablarch.common.web.handler.threadcontext;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.core.ThreadContext;
+import nablarch.core.repository.ObjectLoader;
+import nablarch.core.repository.SystemRepository;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * {@link TimeZoneAttributeInHttpUtilTest} のテスト。
+ *
+ */
+public class TimeZoneAttributeInHttpUtilTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mocked
+    private HttpRequest mockHttpRequest;
+
+    @Mocked
+    private HttpServletRequest mockServletRequest;
+
+    @Mocked
+    private HttpServletResponse mockServletResponse;
+
+    @Mocked
+    private ServletContext mockServletContext;
+
+    @Before
+    public void setUp(){
+        new Expectations() {{
+            mockServletRequest.getContextPath();
+            result = "/";
+            mockServletRequest.getRequestURI();
+            result = "/";
+        }};
+    }
+
+    private void setUpRepository(final TimeZoneAttributeInHttpSupport support){
+        // リポジトリにTimeZoneAttributeInHttpSupportを定義
+        SystemRepository.load(new ObjectLoader() {
+            @SuppressWarnings("serial")
+            @Override
+            public Map<String, Object> load() {
+                return new HashMap<String, Object>() {{
+                    put("timeZoneAttribute", support);
+                }};
+            }
+        });
+    }
+
+    /**
+     * {@link TimeZoneAttributeInHttpUtil#keepTimeZone(HttpRequest, ExecutionContext, String)}のテスト。
+     * <p/>
+     * リポジトリに値が無い場合、例外を送出するか。
+     */
+    @Test
+    public void testNotRegisteredInRepository() {
+
+        SystemRepository.clear();
+        ServletExecutionContext ctx = new ServletExecutionContext(mockServletRequest, mockServletResponse, mockServletContext);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("specified timeZoneAttribute is not registered in SystemRepository.");
+
+        TimeZoneAttributeInHttpUtil.keepTimeZone(mockHttpRequest, ctx, "ja");
+    }
+
+    /**
+     * {@link TimeZoneAttributeInHttpUtil#keepTimeZone(HttpRequest, ExecutionContext, String)}のテスト。
+     * <p/>
+     * 設定したタイムゾーンがサポート外だった場合、リターンするか。
+     */
+    @Test
+    public void testNoSupportTimeZone(){
+
+        final TimeZoneAttributeInHttpSupport support = new TimeZoneAttributeInHttpSupport() {
+            @Override
+            protected void keepTimeZone(HttpRequest req, ServletExecutionContext ctx, String timeZone) {}
+            @Override
+            protected String getKeepingTimeZone(HttpRequest req, ServletExecutionContext ctx) {
+                return null;
+            }
+        };
+        support.setSupportedTimeZones("");
+        setUpRepository(support);
+
+        ServletExecutionContext ctx = new ServletExecutionContext(mockServletRequest, mockServletResponse, mockServletContext);
+
+        ThreadContext.clear();
+        TimeZoneAttributeInHttpUtil.keepTimeZone(mockHttpRequest, ctx, "Asia/Tokyo");
+
+        //サポート外によってリターンするため、スレッドコンテキストが保持するタイムゾーンはnullのはず。
+        assertNull(ThreadContext.getTimeZone());
+
+    }
+
+    /**
+     * {@link TimeZoneAttributeInHttpUtil#keepTimeZone(HttpRequest, ExecutionContext, String)}のテスト。
+     * <p/>
+     * 正常系。スレッドコンテキストに指定したタイムゾーンが設定されているか。
+     */
+    @Test
+    public void testKeepTimeZone() {
+
+        final TimeZoneAttributeInHttpSupport support = new TimeZoneAttributeInHttpSupport() {
+            @Override
+            protected void keepTimeZone(HttpRequest req, ServletExecutionContext ctx, String timeZone) {
+            }
+
+            @Override
+            protected String getKeepingTimeZone(HttpRequest req, ServletExecutionContext ctx) {
+                return null;
+            }
+        };
+        support.setSupportedTimeZones("Asia/Tokyo");
+        setUpRepository(support);
+
+        ServletExecutionContext ctx = new ServletExecutionContext(mockServletRequest, mockServletResponse, mockServletContext);
+        ThreadContext.clear();
+        TimeZoneAttributeInHttpUtil.keepTimeZone(mockHttpRequest, ctx, "Asia/Tokyo");
+
+        assertEquals("日本標準時", ThreadContext.getTimeZone().getDisplayName());
+    }
+}

--- a/src/test/resources/nablarch/common/web/handler/threadcontext/cookie.xml
+++ b/src/test/resources/nablarch/common/web/handler/threadcontext/cookie.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+スレッドコンテキスト初期化ハンドラの設定ファイル
+-->
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration  ../../component-configuration.xsd">
+
+  <!-- JDKごとにテストで使用するjettyのバージョンの変更 -->
+  <import file="jetty-config.xml"/>
+
+  <component name="languageAttribute"
+             class="nablarch.common.web.handler.threadcontext.LanguageAttributeInHttpCookie">
+    <property name="defaultLanguage" value="es" />
+    <property name="supportedLanguages" value="en,it,ja,es,zh" />
+    <property name="cookieName" value="cookieNameTest" />
+  </component>
+
+  <component name="timeZoneAttribute"
+             class="nablarch.common.web.handler.threadcontext.TimeZoneAttributeInHttpCookie">
+    <property name="defaultTimeZone" value="Europe/Madrid" />
+    <property name="supportedTimeZones" value="America/New_York, Europe/Rome, Asia/Tokyo, Europe/Madrid, Asia/Shanghai" />
+    <property name="cookieName" value="cookieNameTest" />
+  </component>
+
+</component-configuration>

--- a/src/test/resources/nablarch/common/web/handler/threadcontext/cookie_secure.xml
+++ b/src/test/resources/nablarch/common/web/handler/threadcontext/cookie_secure.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+スレッドコンテキスト初期化ハンドラの設定ファイル
+-->
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration  ../../component-configuration.xsd">
+  
+  <component name="languageAttribute"
+             class="nablarch.common.web.handler.threadcontext.LanguageAttributeInHttpCookie">
+    <property name="defaultLanguage" value="es" />
+    <property name="supportedLanguages" value="en,it,ja,es,zh" />
+    <property name="cookieSecure" value="true" />
+  </component>
+
+  <component name="timeZoneAttribute"
+             class="nablarch.common.web.handler.threadcontext.TimeZoneAttributeInHttpCookie">
+    <property name="defaultTimeZone" value="Europe/Madrid" />
+    <property name="supportedTimeZones" value="America/New_York, Europe/Rome, Asia/Tokyo, Europe/Madrid, Asia/Shanghai" />
+    <property name="cookieSecure" value="true" />
+  </component>
+
+</component-configuration>

--- a/src/test/resources/nablarch/common/web/handler/threadcontext/no_support.xml
+++ b/src/test/resources/nablarch/common/web/handler/threadcontext/no_support.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+スレッドコンテキスト初期化ハンドラの設定ファイル
+-->
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration  ../../component-configuration.xsd">
+  
+</component-configuration>

--- a/src/test/resources/nablarch/common/web/handler/threadcontext/session.xml
+++ b/src/test/resources/nablarch/common/web/handler/threadcontext/session.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+スレッドコンテキスト初期化ハンドラの設定ファイル
+-->
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration  ../../component-configuration.xsd">
+  
+  <component name="languageAttribute"
+             class="nablarch.common.web.handler.threadcontext.LanguageAttributeInHttpSession">
+    <property name="defaultLanguage" value="es" />
+    <property name="supportedLanguages" value="en,it,ja,es,zh" />
+  </component>
+
+  <component name="timeZoneAttribute"
+             class="nablarch.common.web.handler.threadcontext.TimeZoneAttributeInHttpSession">
+    <property name="defaultTimeZone" value="Europe/Madrid" />
+    <property name="supportedTimeZones" value="America/New_York, Europe/Rome, Asia/Tokyo, Europe/Madrid, Asia/Shanghai" />
+  </component>
+  
+</component-configuration>


### PR DESCRIPTION
https://nablarch.atlassian.net/browse/NAB-372
上記に対応しました。