### PR TITLE
CSRFの検証失敗時にログを出力するように変更

### DIFF
--- a/src/main/java/nablarch/fw/web/handler/csrf/BadRequestVerificationFailureHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/csrf/BadRequestVerificationFailureHandler.java
@@ -1,5 +1,7 @@
 package nablarch.fw.web.handler.csrf;
 
+import nablarch.core.log.Logger;
+import nablarch.core.log.LoggerManager;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
@@ -7,12 +9,23 @@ import nablarch.fw.web.HttpResponse;
 /**
  * CSRFトークンの検証失敗時にBadRequest(400)のレスポンスを返すクラス。
  *
+ * INFOレベルで検証失敗時のログを出力する。
+ *
  * @author Kiyohito Itoh
  */
 public class BadRequestVerificationFailureHandler implements VerificationFailureHandler {
+
+    /** ロガー */
+    private static Logger LOGGER = LoggerManager.get(BadRequestVerificationFailureHandler.class);
+
     @Override
     public HttpResponse handle(
             HttpRequest request, ExecutionContext context, String userSentToken, String sessionAssociatedToken) {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.logInfo(
+                    String.format("CSRF token verification failed. userSentToken=[%s] sessionAssociatedToken=[%s]",
+                            userSentToken, sessionAssociatedToken));
+        }
         return HttpResponse.Status.BAD_REQUEST.handle(request, context);
     }
 }

--- a/src/test/java/nablarch/fw/web/handler/CsrfTokenVerificationHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/CsrfTokenVerificationHandlerTest.java
@@ -185,6 +185,9 @@ public class CsrfTokenVerificationHandlerTest {
      */
     @Test
     public void testInvalidCsrfToken() {
+
+        OnMemoryLogWriter.clear();
+
         context.addHandler(new GetCsrfToken());
         context.handleNext(new MockHttpRequest("GET / HTTP/1.1"));
         List<Cookie> cookies = servletRes.getCookies();
@@ -199,6 +202,9 @@ public class CsrfTokenVerificationHandlerTest {
                 .setParam(webConfig.getCsrfTokenParameterName(), invalidCsrfToken));
         assertEquals(400, response.getStatusCode());
         assertTrue(response.isBodyEmpty());
+
+        OnMemoryLogWriter.assertLogContains("writer.appLog",
+                "INFO stdout CSRF token verification failed. userSentToken=[invalid csrf token]");
     }
 
     /**


### PR DESCRIPTION
https://nablarch.atlassian.net/browse/NAB-376
上記に対応しました。