### PR TITLE
fix: BasicApplicationDisposerのdisposablesプロパティをdisposableListに名称変更した対応の漏れ

### DIFF
--- a/src/test/resources/nablarch/fw/web/servlet/nablarch-application-disposer-is-invoked-test.xml
+++ b/src/test/resources/nablarch/fw/web/servlet/nablarch-application-disposer-is-invoked-test.xml
@@ -6,7 +6,7 @@
     <component name="disposable3" class="nablarch.fw.web.servlet.MockDisposable" />
 
     <component name="disposer" class="nablarch.core.repository.disposal.BasicApplicationDisposer">
-        <property name="disposables">
+        <property name="disposableList">
             <list>
                 <component-ref name="disposable1" />
                 <component-ref name="disposable2" />


### PR DESCRIPTION
`nablarch-core-repository` で `BasicApplicationDisposer` がもつ `disposables` プロパティを、途中で `disposableList` にリネームする修正を入れた。  
そのとき、テストで使用していたコンポーネント定義ファイル上のプロパティ名が `disposables` のままになっていたため、テストが落ちていた。

コンポーネント定義ファイルの `disposables` プロパティの記述を、 `disposableList` に修正した。