### PR TITLE
何もしないハンドラを追加（nablarch-aws-xray-adaptorから移動）

### DIFF
--- a/src/main/java/nablarch/fw/web/handler/PassThroughHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/PassThroughHandler.java
@@ -1,0 +1,17 @@
+package nablarch.fw.web.handler;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * 何もせず次のハンドラに処理を委譲するハンドラ
+ */
+public class PassThroughHandler implements HttpRequestHandler {
+
+    @Override
+    public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+        return context.handleNext(request);
+    }
+}

--- a/src/test/java/nablarch/common/web/handler/PassThroughHandlerTest.java
+++ b/src/test/java/nablarch/common/web/handler/PassThroughHandlerTest.java
@@ -1,0 +1,84 @@
+package nablarch.common.web.handler;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpCookie;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.handler.PassThroughHandler;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * {@link PassThroughHandler}のテスト
+ */
+public class PassThroughHandlerTest {
+    @Test
+    public void test() {
+        PassThroughHandler handler = new PassThroughHandler();
+        ExecutionContext context = new ExecutionContext()
+                .clearHandlers()
+                .addHandler(handler)
+                .addHandler(new FinalHandler());
+        HttpResponse response = context.handleNext(new MockRequest());
+        assertThat(response.getStatusCode(), is(200));
+    }
+
+    private static class FinalHandler implements HttpRequestHandler {
+        @Override
+        public HttpResponse handle(HttpRequest httpRequest, ExecutionContext executionContext) {
+            return new HttpResponse();
+        }
+    }
+
+    private static class MockRequest extends HttpRequest {
+        @Override
+        public String getMethod() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHttpVersion() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String[]> getParamMap() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] getParam(String s) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HttpRequest setParam(String s, String... strings) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HttpRequest setParamMap(Map<String, String[]> map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getHeaderMap() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHeader(String s) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HttpCookie getCookie() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
This reverts commit 94c80b3f2d7db8a89b912e103f1f7fd47b799670.

AWS X-RayアダプタはAWSから[Javaエージェントとして動作するAWS X-Rayクライアント](https://aws.amazon.com/jp/about-aws/whats-new/2020/09/aws-x-ray-launches-auto-instrumentation-agent-for-java/)がリリースされたためにNablarch5u18でのリリースを見送っていた。
しかし、Javaエージェントの動作を検証したところ、Nablarchでは利用できなかったため、5u19にてリリースすることになった。
