### PR TITLE
デフォルトではボディが空の際にContent-Typeの自動設定を行なわないように修正

### DIFF
--- a/src/main/java/nablarch/common/web/WebConfig.java
+++ b/src/main/java/nablarch/common/web/WebConfig.java
@@ -35,6 +35,9 @@ public class WebConfig {
     /** CSRFトークンを保存するセッションストアの名前 */
     private String csrfTokenSavedStoreName;
 
+    /** ボディを持たないレスポンスでもContent-Typeを設定するか否か */
+    private boolean setContentTypeForResponseWithNoBody = false;
+
     /**
      * 二重サブミット防止トークンをHTMLに埋め込む際にinput要素のname属性に設定する名前を取得する。
      * @return 二重サブミット防止トークンをHTMLに埋め込む際にinput要素のname属性に設定する名前
@@ -173,5 +176,25 @@ public class WebConfig {
      */
     public void setCsrfTokenSavedStoreName(String csrfTokenSavedStoreName) {
         this.csrfTokenSavedStoreName = csrfTokenSavedStoreName;
+    }
+
+    /**
+     * ボディを持たないレスポンスでもContent-Typeを設定するか否かを取得する。
+     *
+     * @return ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
+     */
+    public boolean getSetContentTypeForResponseWithNoBody() {
+        return setContentTypeForResponseWithNoBody;
+    }
+
+    /**
+     * ボディを持たないレスポンスでもContent-Typeを設定するか否かを設定する。
+     *
+     * デフォルトはfalse。
+     *
+     * @param setContentTypeForResponseWithNoBody ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
+     */
+    public void setSetContentTypeForResponseWithNoBody(boolean setContentTypeForResponseWithNoBody) {
+        this.setContentTypeForResponseWithNoBody = setContentTypeForResponseWithNoBody;
     }
 }

--- a/src/main/java/nablarch/common/web/WebConfig.java
+++ b/src/main/java/nablarch/common/web/WebConfig.java
@@ -36,7 +36,7 @@ public class WebConfig {
     private String csrfTokenSavedStoreName;
 
     /** ボディを持たないレスポンスでもContent-Typeを設定するか否か */
-    private boolean contentTypeForResponseWithNoBodyEnabled = false;
+    private boolean addDefaultContentTypeForNoBodyResponse = false;
 
     /**
      * 二重サブミット防止トークンをHTMLに埋め込む際にinput要素のname属性に設定する名前を取得する。
@@ -183,8 +183,8 @@ public class WebConfig {
      *
      * @return ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
      */
-    public boolean getContentTypeForResponseWithNoBodyEnabled() {
-        return contentTypeForResponseWithNoBodyEnabled;
+    public boolean getAddDefaultContentTypeForNoBodyResponse() {
+        return addDefaultContentTypeForNoBodyResponse;
     }
 
     /**
@@ -192,9 +192,9 @@ public class WebConfig {
      *
      * デフォルトはfalse。
      *
-     * @param contentTypeForResponseWithNoBodyEnabled ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
+     * @param addDefaultContentTypeForNoBodyResponse ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
      */
-    public void setContentTypeForResponseWithNoBodyEnabled(boolean contentTypeForResponseWithNoBodyEnabled) {
-        this.contentTypeForResponseWithNoBodyEnabled = contentTypeForResponseWithNoBodyEnabled;
+    public void setAddDefaultContentTypeForNoBodyResponse(boolean addDefaultContentTypeForNoBodyResponse) {
+        this.addDefaultContentTypeForNoBodyResponse = addDefaultContentTypeForNoBodyResponse;
     }
 }

--- a/src/main/java/nablarch/common/web/WebConfig.java
+++ b/src/main/java/nablarch/common/web/WebConfig.java
@@ -36,7 +36,7 @@ public class WebConfig {
     private String csrfTokenSavedStoreName;
 
     /** ボディを持たないレスポンスでもContent-Typeを設定するか否か */
-    private boolean setContentTypeForResponseWithNoBody = false;
+    private boolean contentTypeForResponseWithNoBodyEnabled = false;
 
     /**
      * 二重サブミット防止トークンをHTMLに埋め込む際にinput要素のname属性に設定する名前を取得する。
@@ -183,8 +183,8 @@ public class WebConfig {
      *
      * @return ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
      */
-    public boolean getSetContentTypeForResponseWithNoBody() {
-        return setContentTypeForResponseWithNoBody;
+    public boolean getContentTypeForResponseWithNoBodyEnabled() {
+        return contentTypeForResponseWithNoBodyEnabled;
     }
 
     /**
@@ -192,9 +192,9 @@ public class WebConfig {
      *
      * デフォルトはfalse。
      *
-     * @param setContentTypeForResponseWithNoBody ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
+     * @param contentTypeForResponseWithNoBodyEnabled ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
      */
-    public void setSetContentTypeForResponseWithNoBody(boolean setContentTypeForResponseWithNoBody) {
-        this.setContentTypeForResponseWithNoBody = setContentTypeForResponseWithNoBody;
+    public void setContentTypeForResponseWithNoBodyEnabled(boolean contentTypeForResponseWithNoBodyEnabled) {
+        this.contentTypeForResponseWithNoBodyEnabled = contentTypeForResponseWithNoBodyEnabled;
     }
 }

--- a/src/main/java/nablarch/fw/web/HttpResponse.java
+++ b/src/main/java/nablarch/fw/web/HttpResponse.java
@@ -517,7 +517,7 @@ public class HttpResponse implements Result {
      * @return デフォルトのContent-Typeを付与すべき時はtrue。
      */
     private boolean needsDefaultContentType() {
-        return WebConfigFinder.getWebConfig().getAddDefaultContentTypeForNoBodyResponse() || !isBodyEmpty();
+        return WebConfigFinder.getWebConfig().getAddDefaultContentTypeForNoBodyResponse() || !body.isEmptyOrBufferZeo();
     }
 
     /**
@@ -531,10 +531,9 @@ public class HttpResponse implements Result {
                 Matcher mt = CHARSET_ATTR_IN_CONTENT_PATH.matcher(contentType);
                 if (mt.matches()) {
                     charset = Charset.forName(mt.group(1));
-                } else {
-                    charset = UTF_8;
                 }
-            } else {
+            }
+            if (charset == null) {
                 charset = UTF_8;
             }
         }

--- a/src/main/java/nablarch/fw/web/HttpResponse.java
+++ b/src/main/java/nablarch/fw/web/HttpResponse.java
@@ -517,7 +517,7 @@ public class HttpResponse implements Result {
      * @return デフォルトのContent-Typeを付与すべき時はtrue。
      */
     private boolean needsDefaultContentType() {
-        return WebConfigFinder.getWebConfig().getAddDefaultContentTypeForNoBodyResponse() || !body.isEmptyOrBufferZeo();
+        return WebConfigFinder.getWebConfig().getAddDefaultContentTypeForNoBodyResponse() || !isBodyEmpty();
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/HttpResponse.java
+++ b/src/main/java/nablarch/fw/web/HttpResponse.java
@@ -505,7 +505,7 @@ public class HttpResponse implements Result {
     @Published
     public String getContentType() {
         String contentType = headers.get("Content-Type");
-        if (contentType == null && isSetDefaultContentType()) {
+        if (contentType == null && needsDefaultContentType()) {
             headers.put("Content-Type", "text/plain;charset=UTF-8");
         }
         return headers.get("Content-Type");
@@ -516,7 +516,7 @@ public class HttpResponse implements Result {
      *
      * @return デフォルトのContent-Typeを付与すべき時はtrue。
      */
-    private boolean isSetDefaultContentType() {
+    private boolean needsDefaultContentType() {
         return WebConfigFinder.getWebConfig().getAddDefaultContentTypeForNoBodyResponse() || !isBodyEmpty();
     }
 

--- a/src/main/java/nablarch/fw/web/HttpResponse.java
+++ b/src/main/java/nablarch/fw/web/HttpResponse.java
@@ -19,6 +19,8 @@ import java.util.regex.Pattern;
 import javax.activation.MimetypesFileTypeMap;
 import javax.servlet.http.Cookie;
 
+import nablarch.common.web.WebConfig;
+import nablarch.common.web.WebConfigFinder;
 import nablarch.core.util.StringUtil;
 import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
@@ -488,6 +490,7 @@ public class HttpResponse implements Result {
     /**
      * Content-Typeの値を取得する。
      * <p/>
+     * webConfigコンポーネントのSetContentTypeForResponseWithNoBodyフラグがtrueかつ、
      * Content-Typeが設定されていない場合は、"text/plain;charset=UTF-8"を設定して返す。
      * このメソッドの処理は以下のソースコードと等価である。
      * <code><pre>
@@ -498,9 +501,12 @@ public class HttpResponse implements Result {
      */
     @Published
     public String getContentType() {
-        String contentType = headers.get("Content-Type");
-        if (contentType == null) {
-            headers.put("Content-Type", "text/plain;charset=UTF-8");
+        WebConfig webConfig = WebConfigFinder.getWebConfig();
+        if (webConfig.getSetContentTypeForResponseWithNoBody()) {
+            String contentType = headers.get("Content-Type");
+            if (contentType == null) {
+                headers.put("Content-Type", "text/plain;charset=UTF-8");
+            }
         }
         return headers.get("Content-Type");
     }
@@ -512,6 +518,9 @@ public class HttpResponse implements Result {
     public Charset getCharset() {
         if (charset == null) {
             String contentType = getContentType();
+            if (contentType == null) {
+                contentType = "";
+            }
             Matcher mt = CHARSET_ATTR_IN_CONTENT_PATH.matcher(contentType);
             if (mt.matches()) {
                 charset = Charset.forName(mt.group(1));

--- a/src/main/java/nablarch/fw/web/ResponseBody.java
+++ b/src/main/java/nablarch/fw/web/ResponseBody.java
@@ -73,6 +73,10 @@ public class ResponseBody {
     /** 内部バッファ(オンヒープ) */
     private ByteBuffer buffer = null;
 
+    /** 内部バッファのポジション。
+     * (ボディが空か否かの判定にBuffer#flip()前のポジションを使用するため、bufferに書き込み時にポジションをこの変数に待避する) */
+    private int bufferPosition = 0;
+
     /** 内部バッファ(一時ファイル) */
     private File tempFile = null;
 
@@ -103,9 +107,7 @@ public class ResponseBody {
         if(contentPath != null || input !=null || tempFile != null){
             return false;
         }
-        // streamに書き込む前処理としてgetInputStream()を呼び出した時点でbufferはnullでなくなるため、
-        // 条件にbufferのポジションも使用する。
-        return buffer == null || buffer.position() <= 0;
+        return buffer == null || bufferPosition <= 0;
     }
 
     /**
@@ -204,6 +206,7 @@ public class ResponseBody {
             expandTo(buffer.capacity() + bytes.remaining());
         }
         buffer.put(bytes);
+        bufferPosition = buffer.position();
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/ResponseBody.java
+++ b/src/main/java/nablarch/fw/web/ResponseBody.java
@@ -101,32 +101,9 @@ public class ResponseBody {
      */
     public boolean isEmpty() {
         return contentPath == null
-                && input       == null
-                && tempFile    == null
-                && buffer      == null;
-    }
-
-    /**
-     * ボディの内容が設定されていないないか、bufferに書き込まれている量が0の場合にtrueを返す。
-     * <p/>
-     * 「ボディが実質的に空文字列か否か」を判定したい場合に、isEmpty()は使用できないため、本メソッドは存在する。<br />
-     * streamに書き込む前処理としてgetInputStream()を呼び出した時点でbufferはnullでなくなる。<br />
-     * そのためisEmpty()で判定すると「ボディに何も書き込まれていなくても、ボディに値が存在する」と判定される。<br />
-     *
-     * @return ボディの内容が実質空の場合にtrue
-     */
-    public boolean isEmptyOrBufferZeo() {
-        if(contentPath != null || input !=null || tempFile != null){
-            //通常、本メソッドはcontentPath != null及びtempFile != nullの状態で呼びされない。
-            //本メソッドは、HttpResponse#getContentType()呼び出し時にContent-Typeが未設定の際に呼び出されるが、
-            //HttpResponseからcontentPath及びtempFileの値を本クラスに設定する際に
-            // Content-Typeも合わせて設定されるため。
-            return false;
-        }
-        if(buffer != null && buffer.position() > 0){
-            return false;
-        }
-        return true;
+            && input       == null
+            && tempFile    == null
+            && buffer      == null;
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/ResponseBody.java
+++ b/src/main/java/nablarch/fw/web/ResponseBody.java
@@ -105,10 +105,7 @@ public class ResponseBody {
         }
         // streamに書き込む前処理としてgetInputStream()を呼び出した時点でbufferはnullでなくなるため、
         // 条件にbufferのポジションも使用する。
-        if(buffer == null || buffer.position() <= 0){
-            return false;
-        }
-        return true;
+        return buffer == null || buffer.position() <= 0;
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/ResponseBody.java
+++ b/src/main/java/nablarch/fw/web/ResponseBody.java
@@ -100,11 +100,29 @@ public class ResponseBody {
      * @return ボディの内容が設定されていなければtrue
      */
     public boolean isEmpty() {
+        return contentPath == null
+                && input       == null
+                && tempFile    == null
+                && buffer      == null;
+    }
+
+    /**
+     * ボディの内容が設定されていないないか、bufferに書き込まれている量が0の場合にtrueを返す。
+     * <p/>
+     * 「ボディが実質的に空文字列か否か」を判定したい場合に、isEmpty()は使用できないため、本メソッドは存在する。<br />
+     * streamに書き込む前処理としてgetInputStream()を呼び出した時点でbufferはnullでなくなる。<br />
+     * そのためisEmpty()で判定すると「ボディに何も書き込まれていなくても、ボディに値が存在する」と判定される。<br />
+     *
+     * @return ボディの内容が実質空の場合にtrue
+     */
+    public boolean isEmptyOrBufferZeo() {
         if(contentPath != null || input !=null || tempFile != null){
+            //通常、本メソッドはcontentPath != null及びtempFile != nullの状態で呼びされない。
+            //本メソッドは、HttpResponse#getContentType()呼び出し時にContent-Typeが未設定の際に呼び出されるが、
+            //HttpResponseからcontentPath及びtempFileの値を本クラスに設定する際に
+            // Content-Typeも合わせて設定されるため。
             return false;
         }
-        // streamに書き込む前処理としてgetInputStream()を呼び出した時点でbufferはnullでなくなるため、
-        // 条件にbufferのポジションも使用する。
         if(buffer != null && buffer.position() > 0){
             return false;
         }

--- a/src/main/java/nablarch/fw/web/ResponseBody.java
+++ b/src/main/java/nablarch/fw/web/ResponseBody.java
@@ -100,10 +100,15 @@ public class ResponseBody {
      * @return ボディの内容が設定されていなければtrue
      */
     public boolean isEmpty() {
-        return contentPath == null
-            && input       == null
-            && tempFile    == null
-            && buffer      == null;
+        if(contentPath != null || input !=null || tempFile != null){
+            return false;
+        }
+        // streamに書き込む前処理としてgetInputStream()を呼び出した時点でbufferはnullでなくなるため、
+        // 条件にbufferのポジションも使用する。
+        if(buffer != null && buffer.position() > 0){
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/ResponseBody.java
+++ b/src/main/java/nablarch/fw/web/ResponseBody.java
@@ -105,7 +105,7 @@ public class ResponseBody {
         }
         // streamに書き込む前処理としてgetInputStream()を呼び出した時点でbufferはnullでなくなるため、
         // 条件にbufferのポジションも使用する。
-        if(buffer != null && buffer.position() > 0){
+        if(buffer == null || buffer.position() <= 0){
             return false;
         }
         return true;

--- a/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
@@ -462,7 +462,7 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
 
         String contentType = res.getContentType();
         if (contentType != null) {
-            ctx.getServletResponse().setContentType(res.getContentType());
+            ctx.getServletResponse().setContentType(contentType);
         }
 
         for (Map.Entry<String, String> header : res.getHeaderMap().entrySet()) {

--- a/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
@@ -256,12 +256,16 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
             if (res.isBodyEmpty() && isErrorResponse(res)) {
                 ctx.getServletResponse().sendError(res.getStatusCode());
             } else {
-                writeHeaders(res, ctx);
+                ctx.getServletResponse().setStatus(res.getStatusCode());
+                setHeaders(res, ctx);
                 InputStream bodyStream = res.getBodyStream();
                 if (bodyStream == null) {
                     // file/classpathスキームのコンテントパスで参照先が存在しない
                     // 場合はシステムエラーとする。
                     bodyStream = getFatalErrorResponse().getBodyStream();
+                }
+                if (usesFlush) {
+                    ctx.getServletResponse().flushBuffer();
                 }
                 writeBody(bodyStream, ctx.getServletResponse());
             }
@@ -419,23 +423,6 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
      */
     public void setContentPathRule(ResourcePathRule contentPathRule) {
         this.contentPathRule = contentPathRule;
-    }
-
-    /**
-     * HTTPステータス・HTTPヘッダの内容をクライアントに送信する。
-     *
-     * @param res HTTPレスポンスオブジェクト
-     * @param ctx 実行コンテキストオブジェクト
-     * @throws IOException ソケットI/Oにおけるエラー
-     */
-    private void writeHeaders(HttpResponse            res,
-                              ServletExecutionContext ctx)
-    throws IOException {
-        ctx.getServletResponse().setStatus(res.getStatusCode());
-        setHeaders(res, ctx);
-        if (usesFlush) {
-            ctx.getServletResponse().flushBuffer();
-        }
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
@@ -256,17 +256,13 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
             if (res.isBodyEmpty() && isErrorResponse(res)) {
                 ctx.getServletResponse().sendError(res.getStatusCode());
             } else {
-                ctx.getServletResponse().setStatus(res.getStatusCode());
-                setHeaders(res, ctx);
                 InputStream bodyStream = res.getBodyStream();
                 if (bodyStream == null) {
                     // file/classpathスキームのコンテントパスで参照先が存在しない
                     // 場合はシステムエラーとする。
                     bodyStream = getFatalErrorResponse().getBodyStream();
                 }
-                if (usesFlush) {
-                    ctx.getServletResponse().flushBuffer();
-                }
+                writeHeaders(res, ctx);
                 writeBody(bodyStream, ctx.getServletResponse());
             }
         } catch (IOException e) {
@@ -423,6 +419,23 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
      */
     public void setContentPathRule(ResourcePathRule contentPathRule) {
         this.contentPathRule = contentPathRule;
+    }
+
+    /**
+     * HTTPステータス・HTTPヘッダの内容をクライアントに送信する。
+     *
+     * @param res HTTPレスポンスオブジェクト
+     * @param ctx 実行コンテキストオブジェクト
+     * @throws IOException ソケットI/Oにおけるエラー
+     */
+    private void writeHeaders(HttpResponse            res,
+                              ServletExecutionContext ctx)
+    throws IOException {
+        ctx.getServletResponse().setStatus(res.getStatusCode());
+        setHeaders(res, ctx);
+        if (usesFlush) {
+            ctx.getServletResponse().flushBuffer();
+        }
     }
 
     /**

--- a/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
@@ -460,7 +460,10 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
     private void setHeaders(HttpResponse            res,
                             ServletExecutionContext ctx) {
 
-        ctx.getServletResponse().setContentType(res.getContentType());
+        String contentType = res.getContentType();
+        if (contentType != null) {
+            ctx.getServletResponse().setContentType(res.getContentType());
+        }
 
         for (Map.Entry<String, String> header : res.getHeaderMap().entrySet()) {
             String key = header.getKey();

--- a/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
@@ -256,13 +256,13 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
             if (res.isBodyEmpty() && isErrorResponse(res)) {
                 ctx.getServletResponse().sendError(res.getStatusCode());
             } else {
+                writeHeaders(res, ctx);
                 InputStream bodyStream = res.getBodyStream();
                 if (bodyStream == null) {
                     // file/classpathスキームのコンテントパスで参照先が存在しない
                     // 場合はシステムエラーとする。
                     bodyStream = getFatalErrorResponse().getBodyStream();
                 }
-                writeHeaders(res, ctx);
                 writeBody(bodyStream, ctx.getServletResponse());
             }
         } catch (IOException e) {

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -6,19 +6,29 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import nablarch.common.web.WebConfig;
+import nablarch.core.repository.ObjectLoader;
+import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.Builder;
 import nablarch.test.support.tool.Hereis;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.servlet.http.Cookie;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class HttpResponseTest {
+
+    @Before
+    public void setUp() {
+        SystemRepository.clear();
+    }
 
     @Test
     public void testDefaultConstructorAndAccessorsWorkProperly() {
@@ -27,7 +37,6 @@ public class HttpResponseTest {
         assertEquals(200       , res.getStatusCode());
         assertEquals("OK"      , res.getReasonPhrase());
         assertEquals("HTTP/1.1", res.getHttpVersion());
-        assertEquals("text/plain;charset=UTF-8", res.getContentType());
         assertEquals(Charset.forName("UTF-8"), res.getCharset());
         /**************************************
         HTTP/1.1 200 OK
@@ -174,7 +183,6 @@ public class HttpResponseTest {
             /**************************************
             HTTP/1.1 200 OK
             Content-Length: 13
-            Content-Type: text/plain;charset=UTF-8
             
             Hello world!
             *************************************/
@@ -213,7 +221,6 @@ public class HttpResponseTest {
         ************************/
         assertEquals(200                       , res.getStatusCode());
         assertEquals("OK"                      , res.getReasonPhrase());
-        assertEquals("text/plain;charset=UTF-8", res.getContentType());
         assertEquals("HTTP/1.1"                , res.getHttpVersion());
     
         res = HttpResponse.parse(Hereis.string());
@@ -311,7 +318,43 @@ public class HttpResponseTest {
     }
 
     @Test
-    public void testGetContentTypeSetContentTypeNull() {
+    public void testGetContentTypeSetContentTypeNullSetContentTypeForResponseWithNoBodyDefault() {
+        HttpResponse res = new HttpResponse();
+        res.setHeader("Content-Type", null);
+        assertNull(res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeSetContentTypeNullWithSetContentTypeForResponseWithNoBodyFalse() {
+        final WebConfig webConfig = new WebConfig();
+        webConfig.setSetContentTypeForResponseWithNoBody(false);
+        SystemRepository.load(new ObjectLoader() {
+            @Override
+            public Map<String, Object> load() {
+                final Map<String, Object> result = new HashMap<String, Object>();
+                result.put("webConfig", webConfig);
+                return result;
+            }
+        });
+
+        HttpResponse res = new HttpResponse();
+        res.setHeader("Content-Type", null);
+        assertNull(res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeSetContentTypeNullWithSetContentTypeForResponseWithNoBodyTrue() {
+        final WebConfig webConfig = new WebConfig();
+        webConfig.setSetContentTypeForResponseWithNoBody(true);
+        SystemRepository.load(new ObjectLoader() {
+            @Override
+            public Map<String, Object> load() {
+                final Map<String, Object> result = new HashMap<String, Object>();
+                result.put("webConfig", webConfig);
+                return result;
+            }
+        });
+
         HttpResponse res = new HttpResponse();
         res.setHeader("Content-Type", null);
         assertEquals("text/plain;charset=UTF-8", res.getContentType());

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -324,6 +324,36 @@ public class HttpResponseTest {
     }
 
     @Test
+    public void testGetContentTypeAfterGetBodyStream() {
+        HttpResponse res = new HttpResponse();
+        res.getBodyStream();
+        assertNull(res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeAfterSetContentPath() {
+        HttpResponse res = new HttpResponse();
+        res.setContentPath("");
+        assertEquals("application/octet-stream",res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeAfterSetBodyStream() {
+        HttpResponse res = new HttpResponse();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("テスト".getBytes());
+        res.setBodyStream(inputStream);
+        assertEquals("text/plain;charset=UTF-8",res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeAfterWrite() {
+        HttpResponse res = new HttpResponse();
+        byte[] expectedBytes = "Hello world!".getBytes();
+        res.write(expectedBytes);
+        assertEquals("text/plain;charset=UTF-8",res.getContentType());
+    }
+
+    @Test
     public void testGetContentTypeNullAddDefaultContentTypeForNoBodyResponseDefault() {
         HttpResponse res = new HttpResponse();
         assertNull(res.getContentType());

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -324,13 +324,13 @@ public class HttpResponseTest {
     }
 
     @Test
-    public void testGetContentTypeSetContentTypeNullContentTypeForResponseWithNoBodyEnabledDefault() {
+    public void testGetContentTypeNullAddDefaultContentTypeForNoBodyResponseDefault() {
         HttpResponse res = new HttpResponse();
         assertNull(res.getContentType());
     }
 
     @Test
-    public void testGetContentTypeExistBodyContentTypeForResponseWithNoBodyEnabledDefault() {
+    public void testGetContentTypeExistBodyWithAddDefaultContentTypeForNoBodyResponseDefault() {
         HttpResponse res = HttpResponse.parse(Hereis.string());
         /***********************
          HTTP/1.1 200 OK
@@ -341,9 +341,9 @@ public class HttpResponseTest {
     }
 
     @Test
-    public void testGetContentTypeContentTypeWithContentTypeForResponseWithNoBodyEnabledTrue() {
+    public void testGetContentTypeWithAddDefaultContentTypeForNoBodyResponseTrue() {
         final WebConfig webConfig = new WebConfig();
-        webConfig.setContentTypeForResponseWithNoBodyEnabled(true);
+        webConfig.setAddDefaultContentTypeForNoBodyResponse(true);
         SystemRepository.load(new ObjectLoader() {
             @Override
             public Map<String, Object> load() {

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -226,9 +226,7 @@ public class HttpResponseTest {
         ************************/
         assertEquals(200                       , res.getStatusCode());
         assertEquals("OK"                      , res.getReasonPhrase());
-        // HttpResponse#parse()呼び出し時、Bodyに空文字列が設定されるため、
-        // 自動でContent-Typeの自動設定対象となる。
-        assertEquals("text/plain;charset=UTF-8", res.getContentType());
+        assertNull(res.getContentType());
         assertEquals("HTTP/1.1"                , res.getHttpVersion());
     
         res = HttpResponse.parse(Hereis.string());
@@ -323,6 +321,36 @@ public class HttpResponseTest {
         HttpResponse res = new HttpResponse();
         res.setHeader("Content-Type", "text/csv: charset=Shift_JIS");
        assertEquals("text/csv: charset=Shift_JIS", res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeAfterGetBodyStream() {
+        HttpResponse res = new HttpResponse();
+        res.getBodyStream();
+        assertNull(res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeAfterSetContentPath() {
+        HttpResponse res = new HttpResponse();
+        res.setContentPath("");
+        assertEquals("application/octet-stream",res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeAfterSetBodyStream() {
+        HttpResponse res = new HttpResponse();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("テスト".getBytes());
+        res.setBodyStream(inputStream);
+        assertEquals("text/plain;charset=UTF-8",res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeAfterWrite() {
+        HttpResponse res = new HttpResponse();
+        byte[] expectedBytes = "Hello world!".getBytes();
+        res.write(expectedBytes);
+        assertEquals("text/plain;charset=UTF-8",res.getContentType());
     }
 
     @Test

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -37,6 +37,7 @@ public class HttpResponseTest {
         assertEquals(200       , res.getStatusCode());
         assertEquals("OK"      , res.getReasonPhrase());
         assertEquals("HTTP/1.1", res.getHttpVersion());
+        assertNull(res.getContentType());
         assertEquals(Charset.forName("UTF-8"), res.getCharset());
         /**************************************
         HTTP/1.1 200 OK
@@ -54,6 +55,9 @@ public class HttpResponseTest {
         assertEquals(Charset.forName("sjis"), res.getCharset());
         
         res.setContentType("text/plain ; charset= \"utf-8\" ");
+        assertEquals(Charset.forName("utf-8"), res.getCharset());
+
+        res.setContentType(null);
         assertEquals(Charset.forName("utf-8"), res.getCharset());
     }
 
@@ -183,6 +187,7 @@ public class HttpResponseTest {
             /**************************************
             HTTP/1.1 200 OK
             Content-Length: 13
+            Content-Type: text/plain;charset=UTF-8
             
             Hello world!
             *************************************/
@@ -221,6 +226,7 @@ public class HttpResponseTest {
         ************************/
         assertEquals(200                       , res.getStatusCode());
         assertEquals("OK"                      , res.getReasonPhrase());
+        assertNull(res.getContentType());
         assertEquals("HTTP/1.1"                , res.getHttpVersion());
     
         res = HttpResponse.parse(Hereis.string());
@@ -318,16 +324,26 @@ public class HttpResponseTest {
     }
 
     @Test
-    public void testGetContentTypeSetContentTypeNullSetContentTypeForResponseWithNoBodyDefault() {
+    public void testGetContentTypeSetContentTypeNullContentTypeForResponseWithNoBodyEnabledDefault() {
         HttpResponse res = new HttpResponse();
-        res.setHeader("Content-Type", null);
         assertNull(res.getContentType());
     }
 
     @Test
-    public void testGetContentTypeSetContentTypeNullWithSetContentTypeForResponseWithNoBodyFalse() {
+    public void testGetContentTypeExistBodyContentTypeForResponseWithNoBodyEnabledDefault() {
+        HttpResponse res = HttpResponse.parse(Hereis.string());
+        /***********************
+         HTTP/1.1 200 OK
+
+         Hello world!
+         ************************/
+        assertEquals("text/plain;charset=UTF-8", res.getContentType());
+    }
+
+    @Test
+    public void testGetContentTypeContentTypeWithContentTypeForResponseWithNoBodyEnabledTrue() {
         final WebConfig webConfig = new WebConfig();
-        webConfig.setSetContentTypeForResponseWithNoBody(false);
+        webConfig.setContentTypeForResponseWithNoBodyEnabled(true);
         SystemRepository.load(new ObjectLoader() {
             @Override
             public Map<String, Object> load() {
@@ -338,25 +354,6 @@ public class HttpResponseTest {
         });
 
         HttpResponse res = new HttpResponse();
-        res.setHeader("Content-Type", null);
-        assertNull(res.getContentType());
-    }
-
-    @Test
-    public void testGetContentTypeSetContentTypeNullWithSetContentTypeForResponseWithNoBodyTrue() {
-        final WebConfig webConfig = new WebConfig();
-        webConfig.setSetContentTypeForResponseWithNoBody(true);
-        SystemRepository.load(new ObjectLoader() {
-            @Override
-            public Map<String, Object> load() {
-                final Map<String, Object> result = new HashMap<String, Object>();
-                result.put("webConfig", webConfig);
-                return result;
-            }
-        });
-
-        HttpResponse res = new HttpResponse();
-        res.setHeader("Content-Type", null);
         assertEquals("text/plain;charset=UTF-8", res.getContentType());
     }
 

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -226,7 +226,9 @@ public class HttpResponseTest {
         ************************/
         assertEquals(200                       , res.getStatusCode());
         assertEquals("OK"                      , res.getReasonPhrase());
-        assertNull(res.getContentType());
+        // HttpResponse#parse()呼び出し時、Bodyに空文字列が設定されるため、
+        // 自動でContent-Typeの自動設定対象となる。
+        assertEquals("text/plain;charset=UTF-8", res.getContentType());
         assertEquals("HTTP/1.1"                , res.getHttpVersion());
     
         res = HttpResponse.parse(Hereis.string());
@@ -321,36 +323,6 @@ public class HttpResponseTest {
         HttpResponse res = new HttpResponse();
         res.setHeader("Content-Type", "text/csv: charset=Shift_JIS");
        assertEquals("text/csv: charset=Shift_JIS", res.getContentType());
-    }
-
-    @Test
-    public void testGetContentTypeAfterGetBodyStream() {
-        HttpResponse res = new HttpResponse();
-        res.getBodyStream();
-        assertNull(res.getContentType());
-    }
-
-    @Test
-    public void testGetContentTypeAfterSetContentPath() {
-        HttpResponse res = new HttpResponse();
-        res.setContentPath("");
-        assertEquals("application/octet-stream",res.getContentType());
-    }
-
-    @Test
-    public void testGetContentTypeAfterSetBodyStream() {
-        HttpResponse res = new HttpResponse();
-        ByteArrayInputStream inputStream = new ByteArrayInputStream("テスト".getBytes());
-        res.setBodyStream(inputStream);
-        assertEquals("text/plain;charset=UTF-8",res.getContentType());
-    }
-
-    @Test
-    public void testGetContentTypeAfterWrite() {
-        HttpResponse res = new HttpResponse();
-        byte[] expectedBytes = "Hello world!".getBytes();
-        res.write(expectedBytes);
-        assertEquals("text/plain;charset=UTF-8",res.getContentType());
     }
 
     @Test

--- a/src/test/java/nablarch/fw/web/handler/HttpErrorHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpErrorHandlerTest.java
@@ -424,7 +424,7 @@ public class HttpErrorHandlerTest {
         String path = "classpath:nablarch/fw/web/handler/http-error-handler-test.xml";
         SystemRepository.load(new DiContainer(new XmlComponentDefinitionLoader(path)));
         
-        // 200
+        // 200 (デフォルトページ未設定)
         
         HttpServletRequest servletReq = createServletRequest("/NormalHandler/index.html");
         ServletExecutionContext context = createExecutionContext(servletReq);
@@ -437,6 +437,7 @@ public class HttpErrorHandlerTest {
         
         assertThat(response.getStatusCode(), is(200));
         assertNull(response.getContentPath());
+        assertThat(response.getBodyString(), is(""));
         
         // 404
         
@@ -450,6 +451,7 @@ public class HttpErrorHandlerTest {
         
         assertThat(response.getStatusCode(), is(404));
         assertThat(response.getContentPath().getPath(), is("/PAGE_NOT_FOUND_ERROR.jsp"));
+        assertThat(response.getBodyString(), is(not("")));
         
         // 403
         
@@ -463,6 +465,7 @@ public class HttpErrorHandlerTest {
         
         assertThat(response.getStatusCode(), is(403));
         assertThat(response.getContentPath().getPath(), is("/PERMISSION-ERROR.jsp"));
+        assertThat(response.getBodyString(), is(not("")));
         
         
         // 400系汎用エラー(ワイルドカード指定)
@@ -477,6 +480,7 @@ public class HttpErrorHandlerTest {
         
         assertThat(response.getStatusCode(), is(409));
         assertThat(response.getContentPath().getPath(), is("/USER_ERROR.jsp"));
+        assertThat(response.getBodyString(), is(not("")));
         
     }
 

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -1,6 +1,5 @@
 package nablarch.fw.web.handler;
 
-import junit.framework.AssertionFailedError;
 import nablarch.TestUtil;
 import nablarch.common.handler.threadcontext.ThreadContextHandler;
 import nablarch.common.web.handler.HttpAccessLogHandler;
@@ -23,19 +22,15 @@ import nablarch.fw.web.download.encorder.DownloadFileNameEncoderEntry;
 import nablarch.fw.web.download.encorder.DownloadFileNameEncoderFactory;
 import nablarch.fw.web.download.encorder.MimeBDownloadFileNameEncoder;
 import nablarch.fw.web.download.encorder.UrlDownloadFileNameEncoder;
-import nablarch.fw.web.handler.responsewriter.CustomResponseWriter;
 import nablarch.fw.web.i18n.DirectoryBasedResourcePathRule;
 import nablarch.fw.web.i18n.FilenameBasedResourcePathRule;
 import nablarch.fw.web.i18n.MockServletContextCreator;
-import nablarch.fw.web.servlet.ServletExecutionContext;
 import nablarch.test.support.log.app.OnMemoryLogWriter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.servlet.ServletException;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -788,11 +783,10 @@ public class HttpResponseHandlerTest {
     }
 
     /**
-     * レスポンスオブジェクトのContentTypeが未設定かつBodyが空の場合
+     * レスポンスオブジェクトのContentTypeが未設定かつBodyが空で無い場合
      */
     @Test
     public void testHandlingOfContentTypeNone() throws Exception {
-
         HttpServer server = TestUtil.createHttpServer();
         server.getHandlerOf(HttpResponseHandler.class).setForceFlushAfterWritingHeaders(false);
         server.addHandler(new Object() {
@@ -808,7 +802,7 @@ public class HttpResponseHandlerTest {
                 new MockHttpRequest("GET /test1 HTTP/1.1")
                 , null
         );
-        assertEquals(res.getContentType(), "text/plain;charset=UTF-8");
+        assertEquals("text/plain;charset=UTF-8", res.getHeader("Content-Type"));
     }
 
     /**
@@ -816,7 +810,6 @@ public class HttpResponseHandlerTest {
      */
     @Test
     public void testHandlingOfBodyEmptyContentTypeNone() throws Exception {
-
         HttpServer server = TestUtil.createHttpServer();
         server.getHandlerOf(HttpResponseHandler.class).setForceFlushAfterWritingHeaders(false);
         server.addHandler(new Object() {
@@ -831,7 +824,7 @@ public class HttpResponseHandlerTest {
                 new MockHttpRequest("GET /test1 HTTP/1.1")
                 , null
         );
-        assertNull(res.getContentType());
+        assertNull(res.getHeader("Content-Type"));
     }
     
     /**

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -788,10 +788,34 @@ public class HttpResponseHandlerTest {
     }
 
     /**
-     * レスポンスオブジェクトのContentTypeが未設定の場合
+     * レスポンスオブジェクトのContentTypeが未設定かつBodyが空の場合
      */
     @Test
     public void testHandlingOfContentTypeNone() throws Exception {
+
+        HttpServer server = TestUtil.createHttpServer();
+        server.getHandlerOf(HttpResponseHandler.class).setForceFlushAfterWritingHeaders(false);
+        server.addHandler(new Object() {
+            public HttpResponse getTest1(HttpRequest req, ExecutionContext ctx) {
+                return new HttpResponse()
+                        .setStatusCode(200)
+                        .write("test string");
+            }
+        }).startLocal();
+
+        //------------------ writeのパターン ------------- //
+        HttpResponse res = server.handle(
+                new MockHttpRequest("GET /test1 HTTP/1.1")
+                , null
+        );
+        assertEquals(res.getContentType(), "text/plain;charset=UTF-8");
+    }
+
+    /**
+     * レスポンスオブジェクトのContentTypeが未設定かつBodyが空の場合
+     */
+    @Test
+    public void testHandlingOfBodyEmptyContentTypeNone() throws Exception {
 
         HttpServer server = TestUtil.createHttpServer();
         server.getHandlerOf(HttpResponseHandler.class).setForceFlushAfterWritingHeaders(false);

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -797,7 +797,6 @@ public class HttpResponseHandlerTest {
             }
         }).startLocal();
 
-        //------------------ writeのパターン ------------- //
         HttpResponse res = server.handle(
                 new MockHttpRequest("GET /test1 HTTP/1.1")
                 , null
@@ -819,7 +818,6 @@ public class HttpResponseHandlerTest {
             }
         }).startLocal();
 
-        //------------------ writeのパターン ------------- //
         HttpResponse res = server.handle(
                 new MockHttpRequest("GET /test1 HTTP/1.1")
                 , null

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -48,10 +48,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * {@link HttpResponseHandlerTest}テスト。
@@ -790,6 +787,28 @@ public class HttpResponseHandlerTest {
         assertEquals(res.getHeader("Content-Length"), null);
     }
 
+    /**
+     * レスポンスオブジェクトのContentTypeが未設定の場合
+     */
+    @Test
+    public void testHandlingOfContentTypeNone() throws Exception {
+
+        HttpServer server = TestUtil.createHttpServer();
+        server.getHandlerOf(HttpResponseHandler.class).setForceFlushAfterWritingHeaders(false);
+        server.addHandler(new Object() {
+            public HttpResponse getTest1(HttpRequest req, ExecutionContext ctx) {
+                return new HttpResponse()
+                        .setStatusCode(200);
+            }
+        }).startLocal();
+
+        //------------------ writeのパターン ------------- //
+        HttpResponse res = server.handle(
+                new MockHttpRequest("GET /test1 HTTP/1.1")
+                , null
+        );
+        assertNull(res.getContentType());
+    }
     
     /**
      * ダウンロードファイル名(Content-Dispositionヘッダ)の

--- a/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
@@ -1,6 +1,7 @@
 package nablarch.fw.web.handler;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
@@ -90,6 +91,8 @@ public class SecureHandlerTest {
                 IsMapContaining.hasEntry("Referrer-Policy", "strict-origin-when-cross-origin"),
                 IsMapContaining.hasEntry("Cache-Control", "no-store")
         ));
+        assertNull(result.getHeaderMap().get("Content-Type"));
+
     }
 
     /**

--- a/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
@@ -81,10 +81,9 @@ public class SecureHandlerTest {
 
         final HttpResponse result = sut.handle(mockHttpRequest, context);
 
-        assertThat(result.getHeaderMap().size(), is(7));
+        assertThat(result.getHeaderMap().size(), is(6));
         assertThat(result.getHeaderMap(), CoreMatchers.<Map<String, String>>allOf(
                 IsMapContaining.hasEntry("Content-Length", "0"),
-                IsMapContaining.hasEntry("Content-Type", "text/plain;charset=UTF-8"),
                 IsMapContaining.hasEntry("X-Frame-Options", "SAMEORIGIN"),
                 IsMapContaining.hasEntry("X-XSS-Protection", "1; mode=block"),
                 IsMapContaining.hasEntry("X-Content-Type-Options", "nosniff"),


### PR DESCRIPTION
## 背景
https://nablarch.atlassian.net/jira/software/c/projects/NAB/issues/NAB-403

## やったこと
- nablarch.fw.web.HttpResponse#getContentType呼び出し時、デフォルト状態では `Content-Type` を自動で設定しないようにしました。
  nablarch.common.web.WebConfig#setSetContentTypeForResponseWithNoBody に値をtrue設定することで、 以前の動作に戻すことが出来ます。

## 確認したこと
- ユニットテストに成功すること