### PR TITLE
一時ファイルが使われるサイズの大きいレスポンスのテストケースを追加

### DIFF
--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -640,7 +640,7 @@ public class HttpResponseHandlerTest {
         ).readLine();
         assertThat(line.length(),is(BODY_SIZE));
         //明示的にContent-Typeを設定していない場合に、Content-Typeが自動設定されることを確認
-        assertNull(res.getHeader("Content-Type"));
+        assertNotNull(res.getHeader("Content-Type"));
     }
 
     /**

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerTest.java
@@ -640,7 +640,7 @@ public class HttpResponseHandlerTest {
         ).readLine();
         assertThat(line.length(),is(BODY_SIZE));
         //明示的にContent-Typeを設定していない場合に、Content-Typeが自動設定されることを確認
-        assertNotNull(res.getHeader("Content-Type"));
+        assertEquals("text/plain;charset=UTF-8", res.getHeader("Content-Type"));
     }
 
     /**


### PR DESCRIPTION
https://github.com/nablarch/nablarch-fw-web/pull/92 対応時に、一時ファイルが使われる場合のテストケースがないことを検知。
https://github.com/nablarch/nablarch-fw-web/pull/92 で加えた変更の一部に一時ファイルの存在有無を確認する箇所があるためテストを追加した。