### PR TITLE
test: jmockit -> mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpUtilTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/TimeZoneAttributeInHttpUtilTest.java
@@ -1,7 +1,8 @@
 package nablarch.common.web.handler.threadcontext;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import nablarch.core.ThreadContext;
 import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
@@ -9,49 +10,39 @@ import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link TimeZoneAttributeInHttpUtilTest} のテスト。
  *
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class TimeZoneAttributeInHttpUtilTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    @Mocked
-    private HttpRequest mockHttpRequest;
+    private final HttpRequest mockHttpRequest = mock(HttpRequest.class);
 
-    @Mocked
-    private HttpServletRequest mockServletRequest;
+    private final HttpServletRequest mockServletRequest = mock(HttpServletRequest.class, RETURNS_DEEP_STUBS);
 
-    @Mocked
-    private HttpServletResponse mockServletResponse;
+    private final HttpServletResponse mockServletResponse = mock(HttpServletResponse.class);
 
-    @Mocked
-    private ServletContext mockServletContext;
+    private final ServletContext mockServletContext = mock(ServletContext.class);
 
     @Before
     public void setUp(){
-        new Expectations() {{
-            mockServletRequest.getContextPath();
-            result = "/";
-            mockServletRequest.getRequestURI();
-            result = "/";
-        }};
+        when(mockServletRequest.getContextPath()).thenReturn("/");
+        when(mockServletRequest.getRequestURI()).thenReturn("/");
     }
 
     private void setUpRepository(final TimeZoneAttributeInHttpSupport support){

--- a/src/test/java/nablarch/common/web/handler/threadcontext/UserIdAttributeInSessionStoreTest.java
+++ b/src/test/java/nablarch/common/web/handler/threadcontext/UserIdAttributeInSessionStoreTest.java
@@ -1,7 +1,5 @@
 package nablarch.common.web.handler.threadcontext;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import nablarch.common.handler.threadcontext.ThreadContextHandler;
 import nablarch.common.handler.threadcontext.UserIdAttribute;
 import nablarch.common.web.session.SessionUtil;
@@ -9,8 +7,9 @@ import nablarch.core.ThreadContext;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Handler;
 import nablarch.fw.Request;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
@@ -34,18 +33,16 @@ public class UserIdAttributeInSessionStoreTest {
     /**
      * セッションストアからユーザIDを取得できた場合
      * 取得した値がスレッドコンテキストに設定されること
-     *
-     * @param sessionUtil モック化セッションユーティリティ
      */
     @Test
-    @Ignore("jacoco と jmockit が競合してエラーになるため")
-    public void testUserIdAttributeOnGuestContextOnLoginUserContext(@Mocked final SessionUtil sessionUtil) {
+    public void testUserIdAttributeOnGuestContextOnLoginUserContext() {
         final ExecutionContext context = buildExecutionContext();
-        new Expectations() {{
-            SessionUtil.orNull(context, "user.id");
-            result = "user-id";
-        }};
-        context.handleNext(new MockRequest());
+        
+        try (final MockedStatic<SessionUtil> mocked = Mockito.mockStatic(SessionUtil.class)) {
+            mocked.when(() -> SessionUtil.orNull(context, "user.id")).thenReturn("user-id");
+            context.handleNext(new MockRequest());
+        }
+        
         assertThat(ThreadContext.getUserId(), is("user-id"));
     }
 

--- a/src/test/java/nablarch/common/web/interceptor/InjectFormTest.java
+++ b/src/test/java/nablarch/common/web/interceptor/InjectFormTest.java
@@ -1,20 +1,8 @@
 package nablarch.common.web.interceptor;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import nablarch.common.web.interceptor.sample.form.SampleForm;
 import nablarch.core.ThreadContext;
 import nablarch.core.message.ApplicationException;
@@ -30,33 +18,39 @@ import nablarch.fw.web.MockHttpRequest;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.message.MockStringResourceHolder;
-
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link InjectForm}のテスト。
  * @author Kiyohito Itoh
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class InjectFormTest {
 
     @Rule
     public SystemRepositoryResource repositoryResource = new SystemRepositoryResource("nablarch/common/web/interceptor/sample/inject-form-test.xml");
 
-    @Mocked
-    private HttpServletRequest mockHttpServletRequest;
+    private final HttpServletRequest mockHttpServletRequest = mock(HttpServletRequest.class, RETURNS_DEEP_STUBS);
 
-    @Mocked
-    private HttpServletResponse mockHttpServletResponse;
+    private final HttpServletResponse mockHttpServletResponse = mock(HttpServletResponse.class);
 
-    @Mocked
-    private ServletContext mockServletContext;
+    private final ServletContext mockServletContext = mock(ServletContext.class);
 
     private ServletExecutionContext context;
 
@@ -81,26 +75,13 @@ public class InjectFormTest {
 
         ThreadContext.setLanguage(Locale.JAPANESE);
 
-        new Expectations() {{
-            mockHttpServletRequest.getContextPath();
-            result = "";
-            minTimes = 0;
+        when(mockHttpServletRequest.getContextPath()).thenReturn("");
+        when(mockHttpServletRequest.getRequestURI()).thenReturn("/dummy");
+        
+        context = spy(new ServletExecutionContext(mockHttpServletRequest,
+                mockHttpServletResponse, mockServletContext));
 
-            mockHttpServletRequest.getRequestURI();
-            result = "/dummy";
-            minTimes = 0;
-            
-        }};
-        
-        context = new ServletExecutionContext(mockHttpServletRequest,
-                mockHttpServletResponse, mockServletContext);
-        
-        new Expectations(context) {{
-            Map<String, Object> requestScope = new HashMap<String, Object>();
-            context.getRequestScopeMap();
-            result = requestScope;
-            minTimes = 0;
-        }};
+        doReturn(new HashMap<>()).when(context).getRequestScopeMap();
     }
 
     /**

--- a/src/test/java/nablarch/common/web/session/SessionStoreTest.java
+++ b/src/test/java/nablarch/common/web/session/SessionStoreTest.java
@@ -1,22 +1,8 @@
 package nablarch.common.web.session;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.Serializable;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import mockit.Capturing;
-import mockit.Mocked;
 import nablarch.common.web.session.encoder.JavaSerializeStateEncoder;
 import nablarch.common.web.session.store.HiddenStore;
 import nablarch.core.repository.ObjectLoader;
@@ -26,21 +12,30 @@ import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.servlet.HttpRequestWrapper;
 import nablarch.fw.web.servlet.NablarchHttpServletRequestWrapper;
 import nablarch.fw.web.servlet.ServletExecutionContext;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author tajima
  *
  */
 public class SessionStoreTest {
-    @Capturing
-    private HttpServletResponse httpResponse;
+    private final HttpServletResponse httpResponse = mock(HttpServletResponse.class);
 
-    @Mocked
-    private ServletContext servletContext;
+    private final ServletContext servletContext = mock(ServletContext.class);
 
     @Before
     public void setUp() {

--- a/src/test/java/nablarch/common/web/session/SessionTest.java
+++ b/src/test/java/nablarch/common/web/session/SessionTest.java
@@ -1,31 +1,28 @@
 package nablarch.common.web.session;
 
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import mockit.Capturing;
-import mockit.Mocked;
 import nablarch.common.web.session.store.HttpSessionStore;
 import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.servlet.ServletExecutionContext;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author tajima
@@ -33,11 +30,9 @@ import org.junit.Test;
  */
 public class SessionTest {
 
-    @Capturing
-    private HttpServletResponse httpResponse;
+    private final HttpServletResponse httpResponse = mock(HttpServletResponse.class);
 
-    @Mocked
-    private ServletContext servletContext;
+    private final ServletContext servletContext = mock(ServletContext.class);
 
     @SuppressWarnings("serial")
     @Before

--- a/src/test/java/nablarch/common/web/session/SessionUtilTest.java
+++ b/src/test/java/nablarch/common/web/session/SessionUtilTest.java
@@ -1,22 +1,13 @@
 package nablarch.common.web.session;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
-
 import nablarch.common.web.session.store.HiddenStore;
 import nablarch.common.web.session.store.HttpSessionStore;
 import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.servlet.ServletExecutionContext;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -25,8 +16,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import mockit.Capturing;
-import mockit.Mocked;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * {@link SessionUtil}のテスト
@@ -35,11 +34,9 @@ import mockit.Mocked;
  */
 public class SessionUtilTest {
 
-    @Capturing
-    private HttpServletResponse httpResponse;
+    private final HttpServletResponse httpResponse = mock(HttpServletResponse.class);
 
-    @Mocked
-    private ServletContext servletContext;
+    private final ServletContext servletContext = mock(ServletContext.class);
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/nablarch/common/web/session/integration/SessionStoreIntegrationTest.java
+++ b/src/test/java/nablarch/common/web/session/integration/SessionStoreIntegrationTest.java
@@ -1,7 +1,10 @@
 package nablarch.common.web.session.integration;
 
-import mockit.Expectations;
-import nablarch.TestUtil;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
 import nablarch.common.web.session.SessionManager;
 import nablarch.common.web.session.SessionStoreHandler;
 import nablarch.common.web.session.SessionUtil;
@@ -21,16 +24,10 @@ import nablarch.test.support.db.helper.VariousDbTestHelper;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -44,7 +41,6 @@ import static org.junit.Assert.assertThat;
 /**
  * セッションストア機能の結合テスト。
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 @RunWith(DatabaseTestRunner.class)
 public class SessionStoreIntegrationTest {
 
@@ -90,18 +86,8 @@ public class SessionStoreIntegrationTest {
                 .addHandler(new HttpCharacterEncodingHandler())
                 .addHandler(new HttpResponseHandler())
                 .addHandler(sessionStoreHandler);
-
-        final HttpResponse unused = new HttpResponse();
-        new Expectations(unused) {
-            {
-                HttpResponse.parse(anyString);
-                minTimes = 0;
-                HttpResponse.parse((byte[]) withNotNull());
-                minTimes = 0;
-            }
-        };
     }
-
+    
     /**
      * 保存した値を取得できること。
      */

--- a/src/test/java/nablarch/common/web/session/store/HiddenStoreTest.java
+++ b/src/test/java/nablarch/common/web/session/store/HiddenStoreTest.java
@@ -1,10 +1,12 @@
 package nablarch.common.web.session.store;
 
-import nablarch.common.web.session.MockHttpServletRequest;
-import mockit.Mocked;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.xml.bind.DatatypeConverter;
 import nablarch.common.encryption.AesEncryptor;
 import nablarch.common.encryption.Encryptor;
 import nablarch.common.web.session.EncodeException;
+import nablarch.common.web.session.MockHttpServletRequest;
 import nablarch.common.web.session.SessionEntry;
 import nablarch.common.web.session.encoder.JavaSerializeEncryptStateEncoder;
 import nablarch.common.web.session.encoder.JavaSerializeStateEncoder;
@@ -14,18 +16,28 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.xml.bind.DatatypeConverter;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 /**
  * {@link HiddenStore}のテスト。
@@ -37,11 +49,9 @@ import static org.junit.Assert.*;
  */
 public class HiddenStoreTest {
 
-    @Mocked
-    private ServletContext unusedHttpContext;
+    private final ServletContext unusedHttpContext = mock(ServletContext.class);
 
-    @Mocked
-    private HttpServletResponse unusedHttpResponse;
+    private final HttpServletResponse unusedHttpResponse = mock(HttpServletResponse.class);
 
     private HiddenStore store;
 

--- a/src/test/java/nablarch/common/web/session/store/HttpSessionStoreTest.java
+++ b/src/test/java/nablarch/common/web/session/store/HttpSessionStoreTest.java
@@ -1,29 +1,26 @@
 package nablarch.common.web.session.store;
 
-import mockit.Mocked;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletResponse;
 import nablarch.common.web.session.MockHttpServletRequest;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletResponse;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * {@link HttpSessionStore}のテスト。
  */
 public class HttpSessionStoreTest {
 
-    @Mocked
-    private ServletContext unusedHttpContext;
+    private final ServletContext unusedHttpContext = mock(ServletContext.class);
 
-    @Mocked
-    private HttpServletResponse unusedHttpResponse;
+    private final HttpServletResponse unusedHttpResponse = mock(HttpServletResponse.class);
 
     @Before
     public void setUp() {

--- a/src/test/java/nablarch/common/web/validator/BeanValidationStrategyTest.java
+++ b/src/test/java/nablarch/common/web/validator/BeanValidationStrategyTest.java
@@ -1,29 +1,9 @@
 package nablarch.common.web.validator;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.beans.HasPropertyWithValue.*;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
-import org.hamcrest.collection.IsIterableContainingInOrder;
-import org.hamcrest.collection.IsIterableWithSize;
-
 import nablarch.common.web.interceptor.InjectForm;
 import nablarch.common.web.validator.bean.SampleBean;
 import nablarch.common.web.validator.bean.UserForm;
@@ -43,35 +23,51 @@ import nablarch.fw.web.MockHttpRequest;
 import nablarch.fw.web.handler.NormalizationHandler;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import nablarch.test.support.SystemRepositoryResource;
-
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link InjectForm}のテスト(Bean Validationによるバリデーション).
  *
  * @author sumida
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class BeanValidationStrategyTest {
 
     @Rule
     public SystemRepositoryResource repositoryResource
             = new SystemRepositoryResource("nablarch/common/web/validator/inject-bean-test.xml");
 
-    @Mocked
-    private HttpServletRequest mockHttpServletRequest;
+    private final HttpServletRequest mockHttpServletRequest = mock(HttpServletRequest.class, RETURNS_DEEP_STUBS);
 
-    @Mocked
-    private HttpServletResponse mockHttpServletResponse;
+    private final HttpServletResponse mockHttpServletResponse = mock(HttpServletResponse.class);
 
-    @Mocked
-    private ServletContext mockServletContext;
+    private final ServletContext mockServletContext = mock(ServletContext.class);
 
     private ServletExecutionContext context;
 
@@ -79,26 +75,13 @@ public class BeanValidationStrategyTest {
     public void setUp() throws Exception {
         ThreadContext.setLanguage(Locale.JAPANESE);
 
-        new Expectations() {{
-            mockHttpServletRequest.getContextPath();
-            result = "";
-            minTimes = 0;
+        when(mockHttpServletRequest.getContextPath()).thenReturn("");
+        when(mockHttpServletRequest.getRequestURI()).thenReturn("/dummy");
 
-            mockHttpServletRequest.getRequestURI();
-            result = "/dummy";
-            minTimes = 0;
+        context = spy(new ServletExecutionContext(mockHttpServletRequest,
+                mockHttpServletResponse, mockServletContext));
 
-        }};
-
-        context = new ServletExecutionContext(mockHttpServletRequest,
-                mockHttpServletResponse, mockServletContext);
-
-        new Expectations(context) {{
-            Map<String, Object> requestScope = new HashMap<String, Object>();
-            context.getRequestScopeMap();
-            result = requestScope;
-            minTimes = 0;
-        }};
+        doReturn(new HashMap<>()).when(context).getRequestScopeMap();
     }
 
     /**
@@ -292,16 +275,12 @@ public class BeanValidationStrategyTest {
      */
     @Test
     public void testSortMessages() throws Exception {
-        new Expectations() {{
-            final List<String> paramNames = new ArrayList<String>();
-            paramNames.add("form.name");
-            paramNames.add("form.sub.sub3");
-            paramNames.add("form.birthday");
-            paramNames.add("form.age");
-            mockHttpServletRequest.getParameterNames();
-            result = Collections.enumeration(paramNames);
-            minTimes = 0;
-        }};
+        final List<String> paramNames = new ArrayList<>();
+        paramNames.add("form.name");
+        paramNames.add("form.sub.sub3");
+        paramNames.add("form.birthday");
+        paramNames.add("form.age");
+        when(mockHttpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(paramNames));
 
         final Object action = new Object() {
             @InjectForm(form = UserForm.class, prefix = "form")
@@ -355,16 +334,13 @@ public class BeanValidationStrategyTest {
                 return result;
             }
         });
-        new Expectations() {{
-            final List<String> paramNames = new ArrayList<String>();
-            paramNames.add("form.name");
-            paramNames.add("form.sub.sub3");
-            paramNames.add("form.birthday");
-            paramNames.add("form.age");
-            mockHttpServletRequest.getParameterNames();
-            result = Collections.enumeration(paramNames);
-            minTimes = 0;
-        }};
+        
+        final List<String> paramNames = new ArrayList<>();
+        paramNames.add("form.name");
+        paramNames.add("form.sub.sub3");
+        paramNames.add("form.birthday");
+        paramNames.add("form.age");
+        when(mockHttpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(paramNames));
 
         final Object action = new Object() {
             @InjectForm(form = UserForm.class, prefix = "form")

--- a/src/test/java/nablarch/fw/web/HttpCookieTest.java
+++ b/src/test/java/nablarch/fw/web/HttpCookieTest.java
@@ -1,23 +1,16 @@
 package nablarch.fw.web;
 
+import jakarta.servlet.http.Cookie;
+import nablarch.test.support.reflection.ReflectionUtil;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.servlet.http.Cookie;
-
-import nablarch.TestUtil;
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import mockit.Deencapsulation;
-import mockit.Mocked;
 
 /**
  * {@link HttpCookie}のテストクラス。
@@ -31,9 +24,9 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testGetMaxAge(@Mocked final Cookie cookie) throws Exception {
+    public void testGetMaxAge() throws Exception {
         sut = new HttpCookie();
-        Deencapsulation.setField(sut, "maxAge", 100);
+        ReflectionUtil.setFieldValue(sut, "maxAge", 100);
         assertThat("Max-Ageを取得できること", sut.getMaxAge(), is(100));
     }
 
@@ -42,10 +35,10 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testSetMaxAge(@Mocked final Cookie cookie) throws Exception {
+    public void testSetMaxAge() throws Exception {
         sut = new HttpCookie();
         sut.setMaxAge(200);
-        assertThat("Max-Ageを設定できること", (Integer) Deencapsulation.getField(sut, "maxAge") , is(200));
+        assertThat("Max-Ageを設定できること", (Integer) ReflectionUtil.getFieldValue(sut, "maxAge") , is(200));
 
     }
 
@@ -54,9 +47,9 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testGetPath(@Mocked final Cookie cookie) throws Exception {
+    public void testGetPath() throws Exception {
         sut = new HttpCookie();
-        Deencapsulation.setField(sut, "path", "/test");
+        ReflectionUtil.setFieldValue(sut, "path", "/test");
         assertThat("Pathを取得できること", sut.getPath(), is("/test"));
     }
 
@@ -65,10 +58,10 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testSetPath(@Mocked final Cookie cookie) throws Exception {
+    public void testSetPath() throws Exception {
         sut = new HttpCookie();
         sut.setPath("/test");
-        assertThat("Pathを設定できること", Deencapsulation.getField(sut, "path").toString(), is("/test"));
+        assertThat("Pathを設定できること", ReflectionUtil.getFieldValue(sut, "path").toString(), is("/test"));
     }
 
     /**
@@ -76,9 +69,9 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testGetDomain(@Mocked final Cookie cookie) throws Exception {
+    public void testGetDomain() throws Exception {
         sut = new HttpCookie();
-        Deencapsulation.setField(sut, "domain", "example.com");
+        ReflectionUtil.setFieldValue(sut, "domain", "example.com");
         assertThat("Domainを取得できること", sut.getDomain(), is("example.com"));
     }
 
@@ -87,10 +80,10 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testSetDomain(@Mocked final Cookie cookie) throws Exception {
+    public void testSetDomain() throws Exception {
         sut = new HttpCookie();
         sut.setDomain("example.com");
-        assertThat("Domainを設定できること", Deencapsulation.getField(sut, "domain").toString(), is("example.com"));
+        assertThat("Domainを設定できること", ReflectionUtil.getFieldValue(sut, "domain").toString(), is("example.com"));
     }
 
     /**
@@ -98,9 +91,9 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testIsSecure(@Mocked final Cookie cookie) throws Exception {
+    public void testIsSecure() throws Exception {
         sut = new HttpCookie();
-        Deencapsulation.setField(sut, "secure", true);
+        ReflectionUtil.setFieldValue(sut, "secure", true);
         assertThat("Secureを取得できること", sut.isSecure(), is(true));
     }
 
@@ -109,19 +102,19 @@ public class HttpCookieTest {
      * @throws Exception
      */
     @Test
-    public void testSetSecure(@Mocked final Cookie cookie) throws Exception {
+    public void testSetSecure() throws Exception {
         sut = new HttpCookie();
         sut.setSecure(false);
-        assertThat("Secureを設定できること", (Boolean) Deencapsulation.getField(sut, "secure"), is(false));
+        assertThat("Secureを設定できること", (Boolean) ReflectionUtil.getFieldValue(sut, "secure"), is(false));
     }
 
     /**
      * HttpOnlyを取得できることを確認
      */
     @Test
-    public void testIsHttpOnly(@Mocked final Cookie cookie) {
+    public void testIsHttpOnly() {
         sut = new HttpCookie();
-        Deencapsulation.setField(sut, "httpOnly", true);
+        ReflectionUtil.setFieldValue(sut, "httpOnly", true);
         assertThat("HttpOnlyを取得できること", sut.isHttpOnly(), is(true));
     }
 
@@ -129,10 +122,10 @@ public class HttpCookieTest {
      * HttpOnlyを設定できることを確認
      */
     @Test
-    public void testSetHttpOnly(@Mocked final Cookie cookie) {
+    public void testSetHttpOnly() {
         sut = new HttpCookie();
         sut.setHttpOnly(false);
-        assertThat("HttpOnlyを設定できること", (Boolean) Deencapsulation.getField(sut, "httpOnly"), is(false));
+        assertThat("HttpOnlyを設定できること", (Boolean) ReflectionUtil.getFieldValue(sut, "httpOnly"), is(false));
     }
 
     @Test

--- a/src/test/java/nablarch/fw/web/handler/CsrfTokenVerificationHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/CsrfTokenVerificationHandlerTest.java
@@ -16,9 +16,7 @@ import nablarch.fw.web.handler.csrf.VerificationFailureHandler;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import mockit.integration.junit4.JMockit;
 import nablarch.common.web.MockHttpSession;
 import nablarch.common.web.WebConfig;
 import nablarch.common.web.csrf.CsrfTokenUtil;
@@ -48,7 +46,6 @@ import nablarch.test.support.log.app.OnMemoryLogWriter;
  * {@link CsrfTokenVerificationHandler}のテストクラス。
  *
  */
-@RunWith(JMockit.class)
 public class CsrfTokenVerificationHandlerTest {
 
     @Rule

--- a/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerCookieAddTest.java
+++ b/src/test/java/nablarch/fw/web/handler/HttpResponseHandlerCookieAddTest.java
@@ -1,10 +1,5 @@
 package nablarch.fw.web.handler;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
-
-import java.nio.charset.Charset;
-
 import nablarch.TestUtil;
 import nablarch.core.ThreadContext;
 import nablarch.core.repository.SystemRepository;
@@ -15,31 +10,42 @@ import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpRequestHandler;
 import nablarch.fw.web.HttpResponse;
 import nablarch.fw.web.MockHttpRequest;
-
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-import mockit.Expectations;
-import mockit.Verifications;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 
 /**
  * {@link HttpResponseHandler}のCookie追加のテスト。
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class HttpResponseHandlerCookieAddTest {
+    
+    private MockedStatic<HttpResponse> mocked;
 
     @Before
     public void setUp() throws Exception {
         SystemRepository.clear();
         ThreadContext.clear();
-        final HttpResponse unused = new HttpResponse();
-        new Expectations(unused) {{
-            HttpResponse.parse((byte[]) withNotNull());
-            minTimes = 0;
-            HttpResponse.parse(anyString);
-            minTimes = 0;
-        }};
+        mocked = Mockito.mockStatic(HttpResponse.class, CALLS_REAL_METHODS);
+        mocked.when(() -> HttpResponse.parse(anyString())).thenReturn(null);
+        mocked.when(() -> HttpResponse.parse(any(byte[].class))).thenReturn(null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mocked.close();
     }
 
     /**
@@ -70,16 +76,16 @@ public class HttpResponseHandlerCookieAddTest {
                 .startLocal()
                 .handle(new MockHttpRequest("GET / HTTP/1.1"), new ExecutionContext());
 
-        new Verifications() {{
-            byte[] bytes;
-            HttpResponse.parse(bytes = withCapture());
-            String messages = StringUtil.toString(bytes, Charset.forName("UTF-8"));
-            assertThat(messages, is(containsString("HTTP/1.1 200 OK")));
-            assertThat(messages, is(containsString("cookie add test")));
-            assertThat(messages, is(containsString("Set-Cookie: Test1-Name=Test1-Value; Path=/cookie1")));
-            assertThat(messages, is(containsString("Set-Cookie: Test2-Name=Test2-Value; Path=/cookie2")));
-            assertThat(messages, is(containsString("Set-Cookie: Test3-Name=Test3-Value; Path=/cookie2")));
-        }};
+        final ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        mocked.verify(() -> HttpResponse.parse(captor.capture()), atLeastOnce());
+
+        final byte[] bytes = captor.getValue();
+        String messages = StringUtil.toString(bytes, StandardCharsets.UTF_8);
+        assertThat(messages, is(containsString("HTTP/1.1 200 OK")));
+        assertThat(messages, is(containsString("cookie add test")));
+        assertThat(messages, is(containsString("Set-Cookie: Test1-Name=Test1-Value; Path=/cookie1")));
+        assertThat(messages, is(containsString("Set-Cookie: Test2-Name=Test2-Value; Path=/cookie2")));
+        assertThat(messages, is(containsString("Set-Cookie: Test3-Name=Test3-Value; Path=/cookie2")));
     }
 
     /**
@@ -110,15 +116,15 @@ public class HttpResponseHandlerCookieAddTest {
                 .startLocal()
                 .handle(new MockHttpRequest("GET / HTTP/1.1"), new ExecutionContext());
 
-        new Verifications() {{
-            byte[] bytes;
-            HttpResponse.parse(bytes = withCapture());
-            String messages = StringUtil.toString(bytes, Charset.forName("UTF-8"));
-            assertThat(messages, is(containsString("HTTP/1.1 302 Found")));
-            assertThat(messages, is(containsString("Location: http://127.0.0.1/dummy")));
-            assertThat(messages, is(containsString("Set-Cookie: Test1-Name=Test1-Value; Path=/cookie1")));
-            assertThat(messages, is(containsString("Set-Cookie: Test2-Name=Test2-Value; Path=/cookie2")));
-            assertThat(messages, is(containsString("Set-Cookie: Test3-Name=Test3-Value; Path=/cookie2")));
-        }};
+        final ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        mocked.verify(() -> HttpResponse.parse(captor.capture()), atLeastOnce());
+
+        final byte[] bytes = captor.getValue();
+        String messages = StringUtil.toString(bytes, StandardCharsets.UTF_8);
+        assertThat(messages, is(containsString("HTTP/1.1 302 Found")));
+        assertThat(messages, is(containsString("Location: http://127.0.0.1/dummy")));
+        assertThat(messages, is(containsString("Set-Cookie: Test1-Name=Test1-Value; Path=/cookie1")));
+        assertThat(messages, is(containsString("Set-Cookie: Test2-Name=Test2-Value; Path=/cookie2")));
+        assertThat(messages, is(containsString("Set-Cookie: Test3-Name=Test3-Value; Path=/cookie2")));
     }
 }

--- a/src/test/java/nablarch/fw/web/handler/ResourceMappingTest.java
+++ b/src/test/java/nablarch/fw/web/handler/ResourceMappingTest.java
@@ -68,7 +68,6 @@ public class ResourceMappingTest {
         } catch(IllegalArgumentException e) {
             Assert.assertTrue(true);
         }
-        Assert.assertTrue(OnMemoryLogWriter.getMessages("writer.memory").isEmpty());
     }
 
     @Test

--- a/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
@@ -1,19 +1,8 @@
 package nablarch.fw.web.handler;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-
-import java.util.Arrays;
-import java.util.Map;
-
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.collection.IsMapContaining;
-
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Handler;
 import nablarch.fw.web.HttpRequest;
@@ -21,33 +10,36 @@ import nablarch.fw.web.HttpResponse;
 import nablarch.fw.web.handler.secure.FrameOptionsHeader;
 import nablarch.fw.web.handler.secure.XssProtectionHeader;
 import nablarch.fw.web.servlet.ServletExecutionContext;
-
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link SecureHandler}のテストクラス。
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class SecureHandlerTest {
 
-    @Mocked
-    private HttpServletRequest mockServletRequest;
+    private final HttpServletRequest mockServletRequest = mock(HttpServletRequest.class, RETURNS_DEEP_STUBS);
 
-    @Mocked
-    private HttpServletResponse mockServletResponse;
+    private final HttpServletResponse mockServletResponse = mock(HttpServletResponse.class);
 
-    @Mocked
-    private ServletContext mockServletContext;
+    private final ServletContext mockServletContext = mock(ServletContext.class);
 
-    @Mocked
-    private HttpRequest mockHttpRequest;
+    private final HttpRequest mockHttpRequest = mock(HttpRequest.class);
 
     /** テスト対象 */
     private SecureHandler sut = new SecureHandler();
@@ -66,12 +58,8 @@ public class SecureHandlerTest {
 
     @Before
     public void setUp() {
-        new Expectations() {{
-            mockServletRequest.getRequestURI();
-            result = "/sampleapp/action/sample";
-            mockServletRequest.getContextPath();
-            result = "sampleapp";
-        }};
+        when(mockServletRequest.getRequestURI()).thenReturn("/sampleapp/action/sample");
+        when(mockServletRequest.getContextPath()).thenReturn("sampleapp");
         context = new ServletExecutionContext(mockServletRequest, mockServletResponse, mockServletContext);
         context.addHandler(handler);
     }

--- a/src/test/java/nablarch/fw/web/handler/health/DbHealthCheckerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/health/DbHealthCheckerTest.java
@@ -1,35 +1,30 @@
 package nablarch.fw.web.handler.health;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import nablarch.core.db.dialect.Dialect;
 import org.junit.Test;
 
 import javax.sql.DataSource;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link DbHealthChecker}のテスト。
  */
 public class DbHealthCheckerTest {
 
-    @Mocked
-    private DataSource dataSource;
+    private final DataSource dataSource = mock(DataSource.class);
 
-    @Mocked
-    private Dialect dialect;
+    private final Dialect dialect = mock(Dialect.class);
 
-    @Mocked
-    private Connection connection;
+    private final Connection connection = mock(Connection.class);
 
-    @Mocked
-    private PreparedStatement statement;
+    private final PreparedStatement statement = mock(PreparedStatement.class);
 
     /**
      * ヘルスチェックに成功した場合。
@@ -37,12 +32,8 @@ public class DbHealthCheckerTest {
     @Test
     public void success() throws Exception {
 
-        new Expectations() {{
-            dataSource.getConnection();
-            result = connection;
-            connection.prepareStatement(dialect.getPingSql());
-            result = statement;
-        }};
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(dialect.getPingSql())).thenReturn(statement);
 
         DbHealthChecker sut = new DbHealthChecker();
         sut.setDataSource(dataSource);
@@ -57,14 +48,9 @@ public class DbHealthCheckerTest {
     @Test
     public void failureByException() throws Exception {
 
-        new Expectations() {{
-            dataSource.getConnection();
-            result = connection;
-            connection.prepareStatement(dialect.getPingSql());
-            result = statement;
-            statement.execute();
-            result = new SQLException();
-        }};
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(dialect.getPingSql())).thenReturn(statement);
+        when(statement.execute()).thenThrow(new SQLException());
 
         DbHealthChecker sut = new DbHealthChecker();
         sut.setDataSource(dataSource);
@@ -79,10 +65,7 @@ public class DbHealthCheckerTest {
     @Test
     public void connectionError() throws Exception {
 
-        new Expectations() {{
-            dataSource.getConnection();
-            result = new SQLException();
-        }};
+        when(dataSource.getConnection()).thenThrow(new SQLException());
 
         DbHealthChecker sut = new DbHealthChecker();
         sut.setDataSource(dataSource);

--- a/src/test/java/nablarch/fw/web/i18n/BasicServletContextCreatorTest.java
+++ b/src/test/java/nablarch/fw/web/i18n/BasicServletContextCreatorTest.java
@@ -1,17 +1,8 @@
 package nablarch.fw.web.i18n;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-
-import java.util.HashMap;
-import java.util.Map;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-
-import mockit.Expectations;
-import mockit.Mocked;
 import nablarch.common.util.BasicRequestIdExtractor;
 import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
@@ -21,6 +12,16 @@ import nablarch.fw.web.servlet.MockServletRequest;
 import nablarch.fw.web.servlet.WebFrontController;
 import org.junit.After;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link BasicRequestIdExtractor}のテスト。
@@ -45,11 +46,11 @@ public class BasicServletContextCreatorTest {
      * セッションからサーブレットコンテキストを取得するケース。
      */
     @Test
-    public void testCreateFromSession(@Mocked final HttpServletRequest request, @Mocked final HttpSession session) {
+    public void testCreateFromSession() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class, RETURNS_DEEP_STUBS);
         
-        new Expectations() {{
-            request.getSession(false); result = session;
-        }};
+        when(request.getSession(false)).thenReturn(session);
         
         assertThat(creator.create(request), instanceOf(ServletContext.class));
     }
@@ -59,7 +60,8 @@ public class BasicServletContextCreatorTest {
      * リポジトリからサーブレットコンテキストを取得するケース。
      */
     @Test
-    public void testCreateFromRepository(@Mocked final HttpServletRequest request) {
+    public void testCreateFromRepository() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
 
         SystemRepository.load(new ObjectLoader() {
             @Override
@@ -72,9 +74,7 @@ public class BasicServletContextCreatorTest {
             }
         });
 
-        new Expectations() {{
-            request.getSession(false); result = null;
-        }};
+        when(request.getSession(false)).thenReturn(null);
 
         assertThat(creator.create(request), instanceOf(ServletContext.class));
     }
@@ -84,11 +84,10 @@ public class BasicServletContextCreatorTest {
      * サーブレットコンテキストを取得できないケース。
      */
     @Test
-    public void testCreateException(@Mocked final HttpServletRequest request) {
+    public void testCreateException() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
 
-        new Expectations() {{
-            request.getSession(false); result = null;
-        }};
+        when(request.getSession(false)).thenReturn(null);
 
         try {
             creator.create(request);

--- a/src/test/java/nablarch/fw/web/i18n/ResourcePathRuleTest.java
+++ b/src/test/java/nablarch/fw/web/i18n/ResourcePathRuleTest.java
@@ -1,19 +1,7 @@
 package nablarch.fw.web.i18n;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
-
-import mockit.Expectations;
-import mockit.Mocked;
 import nablarch.core.ThreadContext;
 import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
@@ -25,6 +13,19 @@ import nablarch.fw.web.servlet.WebFrontController;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link ResourcePathRule}のテスト。
@@ -236,7 +237,8 @@ public class ResourcePathRuleTest {
     }
     
     @Test
-    public void testGetServletContextCreatorDefault(@Mocked final HttpServletRequest request) {
+    public void testGetServletContextCreatorDefault() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
 
         SystemRepository.load(new ObjectLoader() {
             @Override
@@ -247,9 +249,7 @@ public class ResourcePathRuleTest {
             }
         });
         
-        new Expectations() {{
-            request.getSession(false); result = null;
-        }};
+        when(request.getSession(false)).thenReturn(null);
         
         try {
             rule.existsResource("test", request);
@@ -259,7 +259,8 @@ public class ResourcePathRuleTest {
     }
     
     @Test
-    public void testGetServletContextCreatorBasic(@Mocked final HttpServletRequest request) {
+    public void testGetServletContextCreatorBasic() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
 
         SystemRepository.load(new ObjectLoader() {
             @Override
@@ -270,9 +271,7 @@ public class ResourcePathRuleTest {
             }
         });
         
-        new Expectations() {{
-            request.getSession(false); result = null;
-        }};
+        when(request.getSession(false)).thenReturn(null);
         
         rule.setServletContextCreator(new BasicServletContextCreator());
         
@@ -284,7 +283,8 @@ public class ResourcePathRuleTest {
     }
     
     @Test
-    public void testGetServletContextCreatorTest(@Mocked final HttpServletRequest request) {
+    public void testGetServletContextCreatorTest() {
+        final HttpServletRequest request = mock(HttpServletRequest.class, RETURNS_DEEP_STUBS);
 
         SystemRepository.load(new ObjectLoader() {
             @Override

--- a/src/test/java/nablarch/fw/web/servlet/PreventSessionCreationHttpServletRequestWrapperTest.java
+++ b/src/test/java/nablarch/fw/web/servlet/PreventSessionCreationHttpServletRequestWrapperTest.java
@@ -1,15 +1,15 @@
 package nablarch.fw.web.servlet;
 
-import mockit.Mocked;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 /**
  * {@link PreventSessionCreationHttpServletRequestWrapper} のテストクラス。
@@ -17,8 +17,7 @@ import static org.junit.Assert.*;
  * @author Tomoyuki Tanaka
  */
 public class PreventSessionCreationHttpServletRequestWrapperTest {
-    @Mocked
-    public HttpServletRequest request;
+    public HttpServletRequest request = mock(HttpServletRequest.class);
 
     private PreventSessionCreationHttpServletRequestWrapper sut;
 

--- a/src/test/java/nablarch/fw/web/servlet/RepositoryBasedWebFrontControllerTest.java
+++ b/src/test/java/nablarch/fw/web/servlet/RepositoryBasedWebFrontControllerTest.java
@@ -1,21 +1,26 @@
 package nablarch.fw.web.servlet;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.util.Enumeration;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
-
-import mockit.Deencapsulation;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.repository.di.DiContainer;
 import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Handler;
+import nablarch.test.support.reflection.ReflectionUtil;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Enumeration;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * {@link RepositoryBasedWebFrontController}のテストクラス。
@@ -108,7 +113,7 @@ public class RepositoryBasedWebFrontControllerTest {
 
         repoController.init(config);
 
-        WebFrontController actualWebController = Deencapsulation.getField(repoController,"controller");
+        WebFrontController actualWebController = ReflectionUtil.getFieldValue(repoController,"controller");
 
         assertNotSame(defaultWebController,actualWebController);
 

--- a/src/test/java/nablarch/fw/web/servlet/WebFrontControllerTest.java
+++ b/src/test/java/nablarch/fw/web/servlet/WebFrontControllerTest.java
@@ -1,13 +1,8 @@
 package nablarch.fw.web.servlet;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-
-import mockit.Mocked;
-import mockit.Verifications;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import nablarch.TestUtil;
 import nablarch.common.web.session.MockHttpServletRequest;
 import nablarch.core.ThreadContext;
@@ -23,22 +18,30 @@ import nablarch.fw.web.handler.HttpErrorHandler;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Kiyohito Itoh
  */
 public class WebFrontControllerTest {
-    @Mocked
-    public Handler<Object, ?> handler;
-    @Mocked
-    public HttpServletResponse response;
-    @Mocked
-    public FilterChain filterChain;
+    @SuppressWarnings("unchecked")
+    public Handler<Object, ?> handler = mock(Handler.class);
+    public HttpServletResponse response = mock(HttpServletResponse.class);
+    public FilterChain filterChain = mock(FilterChain.class);
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -109,14 +112,13 @@ public class WebFrontControllerTest {
         sut.setPreventSessionCreation(false);
         sut.doFilter(new MockHttpServletRequest().getMockInstance(), response, filterChain);
 
-        new Verifications() {{
-            ExecutionContext context;
-            handler.handle(any, context = withCapture());
+        final ArgumentCaptor<ExecutionContext> captor = ArgumentCaptor.forClass(ExecutionContext.class);
+        verify(handler, atLeastOnce()).handle(any(), captor.capture());
 
-            ServletRequest servletRequest = ((ServletExecutionContext) context).getServletRequest().getRequest();
-            assertThat(servletRequest, is(notNullValue()));
-            assertThat(servletRequest, is(not(instanceOf(PreventSessionCreationHttpServletRequestWrapper.class))));
-        }};
+        final ExecutionContext context = captor.getValue();
+        ServletRequest servletRequest = ((ServletExecutionContext) context).getServletRequest().getRequest();
+        assertThat(servletRequest, is(notNullValue()));
+        assertThat(servletRequest, is(not(instanceOf(PreventSessionCreationHttpServletRequestWrapper.class))));
     }
 
     @Test
@@ -128,13 +130,12 @@ public class WebFrontControllerTest {
         sut.setPreventSessionCreation(true);
         sut.doFilter(new MockHttpServletRequest().getMockInstance(), response, filterChain);
 
-        new Verifications() {{
-            ExecutionContext context;
-            handler.handle(any, context = withCapture());
-
-            ServletRequest servletRequest = ((ServletExecutionContext) context).getServletRequest().getRequest();
-            assertThat(servletRequest, is(instanceOf(PreventSessionCreationHttpServletRequestWrapper.class)));
-        }};
+        final ArgumentCaptor<ExecutionContext> captor = ArgumentCaptor.forClass(ExecutionContext.class);
+        verify(handler, atLeastOnce()).handle(any(), captor.capture());
+        
+        final ExecutionContext context = captor.getValue();
+        ServletRequest servletRequest = ((ServletExecutionContext) context).getServletRequest().getRequest();
+        assertThat(servletRequest, is(instanceOf(PreventSessionCreationHttpServletRequestWrapper.class)));
     }
 
     @After

--- a/src/test/resources/log.properties
+++ b/src/test/resources/log.properties
@@ -24,7 +24,7 @@ writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 loggers.stdout.nameRegex=.*
 loggers.stdout.level=INFO
-loggers.stdout.writerNames=appLog,stdout,verifier
+loggers.stdout.writerNames=appLog,stdout,verifier,memory
 
 loggers.rm.nameRegex=nablarch.fw.web.handler.ResourceMapping
 loggers.rm.level=INFO


### PR DESCRIPTION
`SessionStoreIntegrationTest` で `HttpResponse` の `Expectations` 定義を削除している点について補足。




- `SessionStoreIntegrationTest` のテストは、実際には `HttpServerResource` に委譲されてそちらで実行されている
- `HttpServerResource` の内部では、 `HttpResponse` の `static` メソッドの呼び出しを `Verifications` で検証している
- `Verifications` で検証できるようにするためには `HttpResponse` をモック化している必要がある
- `HttpServerResource` は、 `HttpResponse` のモック化を呼び出し元の方で行うことを想定している
  - クラスの Javadoc に以下のように記載されている

```java
 * 本クラスを使用する場合は、レスポンスメッセージをキャプチャするために、	
 * テストクラスに下記のモックを定義してください。	
 * <pre>	
 * @Mocked("parse") HttpResponse unused;	
 * </pre>
```

- `@Mocked` で静的にモック化することを想定している
  - この方法はテストクラスで行う必要があり、部品的に利用される `HttpServerResource` 側では `HttpResponse` のモック化ができないと考え、こういう方式（呼び出し元で `HttpResponse` をモック化する方式）を採っていると考えられる
- 一方で、 mockito の場合は `MockedStatic` を使って動的にモック化が可能なので、 `HttpServerResource` 内部の必要な箇所でだけ `HttpResponse` をモック化させることができる
- このため、呼び出し元での `HttpResponse` のモック化が不要となり、 `SessionStoreIntegrationTest` からは `HttpResponse` のモック化の定義を削除できるようになった



----

[test: MultipartParserにIOExceptionがスローされた場合の観点のテストを追加](https://github.com/nablarch/nablarch-fw-web/pull/114/commits/9ea6a64d8d91a2ca5337d96f94d744963321dfd6) の補足

この修正は、 nablarch-integration-test の修正に起因するものになる。
背景については [nablarch-integration-test の PR](https://github.com/nablarch/nablarch-integration-test/pull/13) を参照。

ここでは、 `ResourceMappingTest` のテストケースを修正（ログ出力のチェックを外していること）について補足する。

`MultipartParserTest` では、ログ出力観点のテストケースを追加した。
修正前の `log.properties` では、デフォルトのロガー(`loggers.stdout`)は `OnMemoryLogWriter` に記録されない設定になっていた（`loggers.stdout` の `writers` に `writers.memory` が設定されていなかった）。
このため、 `OnMemoryLogWriter` でその他のロガーに出力された内容をアサートできるようにするため、 `loggers.stdout` の `writers` に `memory` を追加する修正を行った。
これにより、その他ロガーに出力していたログが `OnMemoryLogWriter` に記録されるようになった。

その結果、 `ResourceMappingTest` のログ出力が空であることを期待していたテストケース(`testConstructorWithIllegalArgument`)が落ちるようになった。

しかし、このテストケースが対象としている `ResourceMappingTest` のコンストラクタは、ログ出力をそもそも行っていない。
つまり、そもそもログ出力の有無をテストする必要性が無いと考えられる。

このため、 `ResourceMappingTest` の `testConstructorWithIllegalArgument` からはログ出力が無いことのテストコードを削除することにした。