### PR TITLE
NTFでCookie引継ぎ可にする対応で、インスペクションの警告を修正

### DIFF
--- a/src/main/java/nablarch/fw/web/HttpCookie.java
+++ b/src/main/java/nablarch/fw/web/HttpCookie.java
@@ -33,6 +33,7 @@ public class HttpCookie extends MapWrapper<String, String> {
     static {
         Method isHttpOnlyMethod = null;
         try {
+            //noinspection JavaReflectionMemberAccess
             isHttpOnlyMethod = Cookie.class.getMethod("isHttpOnly");
         } catch (NoSuchMethodException ignore) {
             // NOP
@@ -41,6 +42,7 @@ public class HttpCookie extends MapWrapper<String, String> {
 
         Method setHttpOnlyMethod = null;
         try {
+            //noinspection JavaReflectionMemberAccess
             setHttpOnlyMethod = Cookie.class.getMethod("setHttpOnly", boolean.class);
         } catch (NoSuchMethodException ignore) {
             // NOP
@@ -185,6 +187,7 @@ public class HttpCookie extends MapWrapper<String, String> {
      *            このクッキーの最長の存続期間（秒）
      * @return このオブジェクト自体
      */
+    @SuppressWarnings("UnusedReturnValue")
     public HttpCookie setMaxAge(final Integer maxAge) {
         this.maxAge = maxAge;
         return this;
@@ -227,6 +230,7 @@ public class HttpCookie extends MapWrapper<String, String> {
      *            このクッキーが送信されるドメイン階層
      * @return このオブジェクト自体
      */
+    @SuppressWarnings("UnusedReturnValue")
     public HttpCookie setDomain(String domain) {
         this.domain = domain;
         return this;
@@ -271,6 +275,7 @@ public class HttpCookie extends MapWrapper<String, String> {
      * @param httpOnly trueの場合は、HttpOnly Cookie
      * @return このオブジェクト自体
      */
+    @SuppressWarnings("UnusedReturnValue")
     public HttpCookie setHttpOnly(final boolean httpOnly) {
         if (SET_HTTP_ONLY_METHOD == null) {
             throw new UnsupportedOperationException("ServletAPI in use is unsupported the HttpOnly attribute. " +

--- a/src/main/java/nablarch/fw/web/HttpResponse.java
+++ b/src/main/java/nablarch/fw/web/HttpResponse.java
@@ -983,7 +983,7 @@ public class HttpResponse implements Result {
             }
         }
         buffer.append(LS + LS)
-              .append(body);
+              .append(body.toString());
         return buffer.toString();
     }
 

--- a/src/main/java/nablarch/fw/web/HttpResponse.java
+++ b/src/main/java/nablarch/fw/web/HttpResponse.java
@@ -353,7 +353,7 @@ public class HttpResponse implements Result {
      */
     @Published
     public int getStatusCode() {
-        if (body != null && body.getContentPath() != null && body.getContentPath().isRedirect() && !isRedirectStatusCode()) {
+        if (body.getContentPath() != null && body.getContentPath().isRedirect() && !isRedirectStatusCode()) {
             return Status.FOUND.code;
         }
         return this.status.code;
@@ -433,6 +433,7 @@ public class HttpResponse implements Result {
      * @return 本オブジェクト
      * @throws IllegalArgumentException HTTPバージョンの書式が無効な場合
      */
+    @SuppressWarnings("UnusedReturnValue")
     public HttpResponse setHttpVersion(String httpVersion) {
         if (!HTTP_VERSION_SYNTAX.matcher(httpVersion).matches()) {
             throw new IllegalArgumentException("invalid : " + httpVersion);
@@ -673,6 +674,7 @@ public class HttpResponse implements Result {
      * @return 本オブジェクト
      * @see Status#SEE_OTHER
      */
+    @SuppressWarnings("UnusedReturnValue")
     public HttpResponse setTransferEncoding(String encoding) {
         headers.put("Transfer-Encoding", encoding);
         return this;
@@ -684,6 +686,7 @@ public class HttpResponse implements Result {
      * @deprecated 本メソッドは、複数のクッキー情報のうち先頭のクッキーを返すことしかできません。
      *              複数のクッキー情報を返すことができる{@link #getCookieList()}を使用してください。
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Published
     @Deprecated
     public HttpCookie getCookie() {
@@ -728,6 +731,7 @@ public class HttpResponse implements Result {
      * @deprecated 本メソッドは、複数のクッキー情報を設定することを意図したメソッド名を持つ
      *             {@link #addCookie(HttpCookie)}に置き換わりました。
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Published
     @Deprecated
     public HttpResponse setCookie(HttpCookie cookie) {
@@ -837,6 +841,7 @@ public class HttpResponse implements Result {
      * リソースを開放する。
      * @return 本オブジェクト
      */
+    @SuppressWarnings("UnusedReturnValue")
     public HttpResponse cleanup() {
         ResponseBody.cleanup();
         return this;
@@ -845,7 +850,7 @@ public class HttpResponse implements Result {
     /**
      * HTTPレスポンスのボディ内容を格納するオブジェクト。
      */
-    private ResponseBody body = new ResponseBody(this);
+    private final ResponseBody body = new ResponseBody(this);
 
     /**
      * HTTPレスポンスボディの内容が設定されていなければ{@code true}を返す。
@@ -995,7 +1000,7 @@ public class HttpResponse implements Result {
         String header = null;
         while (responseMessage.hasNextLine()) {
             String line = responseMessage.nextLine();
-            if (line.length() == 0) {
+            if (line.isEmpty()) {
                 break; // Blank line. following lines are message body.
             }
             if (header == null) {
@@ -1136,7 +1141,7 @@ public class HttpResponse implements Result {
      */
     private void scanHttpStatus(Scanner scanner) {
         String statusCode = scanner.next(HTTP_STATUS_CODE_SYNTAX);
-        this.status = Status.valueOfCode(Integer.valueOf(statusCode));
+        this.status = Status.valueOfCode(Integer.parseInt(statusCode));
     }
 
     /** HTTPステータスコードの書式 */

--- a/src/test/java/nablarch/fw/web/HttpCookieTest.java
+++ b/src/test/java/nablarch/fw/web/HttpCookieTest.java
@@ -2,8 +2,8 @@ package nablarch.fw.web;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -30,13 +30,14 @@ import org.junit.rules.ExpectedException;
  */
 public class HttpCookieTest {
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
     private HttpCookie sut;
 
     /**
      * Max-Ageを取得できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testGetMaxAge(@Mocked final Cookie cookie) throws Exception {
@@ -47,7 +48,7 @@ public class HttpCookieTest {
 
     /**
      * Max-Ageを設定できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testSetMaxAge(@Mocked final Cookie cookie) throws Exception {
@@ -59,7 +60,7 @@ public class HttpCookieTest {
 
     /**
      * Pathを取得できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testGetPath(@Mocked final Cookie cookie) throws Exception {
@@ -70,7 +71,7 @@ public class HttpCookieTest {
 
     /**
      * Pathを設定できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testSetPath(@Mocked final Cookie cookie) throws Exception {
@@ -81,7 +82,7 @@ public class HttpCookieTest {
 
     /**
      * Domainを取得できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testGetDomain(@Mocked final Cookie cookie) throws Exception {
@@ -92,7 +93,7 @@ public class HttpCookieTest {
 
     /**
      * Domainを設定できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testSetDomain(@Mocked final Cookie cookie) throws Exception {
@@ -103,7 +104,7 @@ public class HttpCookieTest {
 
     /**
      * Secureを取得できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testIsSecure(@Mocked final Cookie cookie) throws Exception {
@@ -114,7 +115,7 @@ public class HttpCookieTest {
 
     /**
      * Secureを設定できることを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testSetSecure(@Mocked final Cookie cookie) throws Exception {
@@ -125,7 +126,7 @@ public class HttpCookieTest {
 
     /**
      * ServletAPIのバージョンが3.0以前の場合に、HttpOnly取得時に例外が発生することを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testIsHttpOnly_error() throws Exception {
@@ -145,7 +146,7 @@ public class HttpCookieTest {
 
     /**
      * ServletAPIのバージョンが3.0以前の場合に、HttpOnly設定時に例外が発生することを確認
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void testSetHttpOnly_error() throws Exception {
@@ -271,6 +272,7 @@ public class HttpCookieTest {
             Matchers.hasProperty("message", Matchers.is("Cookie string must not be null."))
         ));
 
+        //noinspection DataFlowIssue
         HttpCookie.fromSetCookieHeader(null);
     }
 
@@ -295,6 +297,7 @@ public class HttpCookieTest {
         cookie.setSecure(true);
         if(TestUtil.isJetty9()) {
             try {
+                //noinspection JavaReflectionMemberAccess
                 Cookie.class.getMethod("setHttpOnly", boolean.class).invoke(cookie, true);
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -31,6 +31,7 @@ public class HttpResponseTest {
         SystemRepository.clear();
     }
 
+    @SuppressWarnings("DanglingJavadoc")
     @Test
     public void testDefaultConstructorAndAccessorsWorkProperly() {
         HttpResponse res = new HttpResponse();
@@ -142,6 +143,7 @@ public class HttpResponseTest {
         cookie1.put("foo", "bar"); // 先頭を固定したいので1個だけ設定
         HttpResponse res = new HttpResponse().addCookie(cookie1);
 
+        //noinspection MismatchedQueryAndUpdateOfCollection
         HttpCookie cookie2 = new HttpCookie();
         cookie2.put("hoge", "hogehoge");
         cookie2.put("fuga", "fugafuga");
@@ -149,6 +151,7 @@ public class HttpResponseTest {
 
         HttpCookie cookie3 = new HttpCookie();
         cookie3.put("egg", "egg");
+        //noinspection deprecation
         res = res.setCookie(cookie3);
 
         List<Cookie> list = res.getCookieList();
@@ -164,6 +167,7 @@ public class HttpResponseTest {
             }
         }
 
+        //noinspection deprecation
         Map.Entry<String, String> result = res.getCookie().entrySet().iterator().next();
         assertEquals(result.getKey(), "foo");
         assertEquals(result.getValue(), "bar");
@@ -171,9 +175,11 @@ public class HttpResponseTest {
         // クッキーが設定されなかった場合
         res = new HttpResponse();
         assertTrue(res.getCookieList().isEmpty());
+        //noinspection deprecation
         assertNull(res.getCookie());
      }
 
+    @SuppressWarnings("DanglingJavadoc")
     @Test
     public void testWritingToBodyBuffer() {
         
@@ -208,6 +214,7 @@ public class HttpResponseTest {
 
         byte[] bytes = new byte[expectedBytes.length];
         InputStream input = res.getBodyStream();
+        //noinspection ResultOfMethodCallIgnored
         input.read(bytes);
         
         assertEquals(expectedBytes.length, bytes.length);
@@ -219,6 +226,7 @@ public class HttpResponseTest {
         assertTrue(res.toString().contains(expectedString));
     }
 
+    @SuppressWarnings("DanglingJavadoc")
     @Test
     public void testParsingHttpResponseMessage() {
         HttpResponse res = HttpResponse.parse(Hereis.string());
@@ -245,6 +253,7 @@ public class HttpResponseTest {
         assertEquals("Hello world!"  , res.getBodyString().trim());
     }
 
+    @SuppressWarnings("DanglingJavadoc")
     @Test
     public void testParsingMultilineHeaders() {
         HttpResponse res = HttpResponse.parse(Hereis.string());
@@ -352,6 +361,7 @@ public class HttpResponseTest {
     }
 
 
+    @SuppressWarnings("DanglingJavadoc")
     @Test
     public void testParsingMultilineSetCookieHeaders() {
         HttpResponse res = HttpResponse.parse(Hereis.string());
@@ -382,6 +392,7 @@ public class HttpResponseTest {
         // assertEquals(true, Cookie.class.getMethod("isHttpOnly").invoke(res.getCookieList().get(1)));
     }
 
+    @SuppressWarnings("DanglingJavadoc")
     @Test
     public void testThrowsErrorWhenItReadsIllegalResponseFormat() {
         try {
@@ -468,6 +479,7 @@ public class HttpResponseTest {
         assertNull(res.getContentType());
     }
 
+    @SuppressWarnings("DanglingJavadoc")
     @Test
     public void testGetContentTypeExistBodyWithAddDefaultContentTypeForNoBodyResponseDefault() {
         HttpResponse res = HttpResponse.parse(Hereis.string());

--- a/src/test/java/nablarch/fw/web/HttpResponseTest.java
+++ b/src/test/java/nablarch/fw/web/HttpResponseTest.java
@@ -143,11 +143,10 @@ public class HttpResponseTest {
         cookie1.put("foo", "bar"); // 先頭を固定したいので1個だけ設定
         HttpResponse res = new HttpResponse().addCookie(cookie1);
 
-        //noinspection MismatchedQueryAndUpdateOfCollection
         HttpCookie cookie2 = new HttpCookie();
         cookie2.put("hoge", "hogehoge");
         cookie2.put("fuga", "fugafuga");
-        res = res.addCookie(cookie1);
+        res = res.addCookie(cookie2);
 
         HttpCookie cookie3 = new HttpCookie();
         cookie3.put("egg", "egg");

--- a/src/test/java/nablarch/fw/web/servlet/NablarchServletContextListenerTest.java
+++ b/src/test/java/nablarch/fw/web/servlet/NablarchServletContextListenerTest.java
@@ -1,5 +1,6 @@
 package nablarch.fw.web.servlet;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
@@ -7,7 +8,6 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -64,7 +64,7 @@ public class NablarchServletContextListenerTest extends LogTestSupport {
         listener.contextInitialized(ctxEvt);
         
         Object obj = SystemRepository.getObject("book");
-        assertThat(Book.class.cast(obj).getName(), is("Nablarch入門Vol2"));
+        assertThat(((Book) obj).getName(), is("Nablarch入門Vol2"));
         
         // 設定値の上書き時の動作設定にOVERRIDEを指定した場合
         // コンポーネント定義を重複させた設定ファイルを指定する。
@@ -79,7 +79,7 @@ public class NablarchServletContextListenerTest extends LogTestSupport {
         listener.contextInitialized(ctxEvt);
         
         obj = SystemRepository.getObject("book");
-        assertThat(Book.class.cast(obj).getName(), is("Nablarch入門Vol2"));
+        assertThat(((Book) obj).getName(), is("Nablarch入門Vol2"));
         
         // 設定値の上書き時の動作設定にDENYを指定した場合
         // コンポーネント定義を重複させた設定ファイルを指定する。
@@ -112,7 +112,7 @@ public class NablarchServletContextListenerTest extends LogTestSupport {
         listener.contextInitialized(ctxEvt);
         
         obj = SystemRepository.getObject("book");
-        assertThat(Book.class.cast(obj).getName(), is("Nablarch入門"));
+        assertThat(((Book) obj).getName(), is("Nablarch入門"));
         
         // 設定値の上書き時の動作設定に規定していない動作ポリシー名が指定された場合
 
@@ -169,7 +169,7 @@ public class NablarchServletContextListenerTest extends LogTestSupport {
     
     /**
      * 設定に応じてリポジトリが初期化されること。(file指定)
-     * @throws IOException 
+     * @throws IOException IOException
      */
     @Test
     public void testRepositoryInitializationForFileConfig() throws IOException {
@@ -202,7 +202,7 @@ public class NablarchServletContextListenerTest extends LogTestSupport {
         listener.contextInitialized(ctxEvt);
         
         Object obj = SystemRepository.getObject("book");
-        assertThat(Book.class.cast(obj).getName(), is("Nablarch入門"));
+        assertThat(((Book) obj).getName(), is("Nablarch入門"));
     }
     
     /**
@@ -284,7 +284,7 @@ public class NablarchServletContextListenerTest extends LogTestSupport {
         listener.contextInitialized(ctxEvt);
 
         Bar bar = SystemRepository.get("bar");
-        assertThat(Foo.getBar(), is(sameInstance(bar)));;
+        assertThat(Foo.getBar(), is(sameInstance(bar)));
     }
 
     /** デフォルトでは、staticプロパティにインジェクションが行われず例外が発生すること。 */

--- a/src/test/resources/nablarch/fw/web/servlet/nablarch-servlet-context-restrequesttest-test.xml
+++ b/src/test/resources/nablarch/fw/web/servlet/nablarch-servlet-context-restrequesttest-test.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component-configuration xmlns="http://tis.co.jp/nablarch/component-configuration"
-                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<component-configuration xmlns="http://tis.co.jp/nablarch/component-configuration">
 
     <component name="restTestConfiguration" class="nablarch.fw.web.servlet.NablarchServletContextListenerTest$Book">
         <property name="name" value="Nablarch入門" />


### PR DESCRIPTION
- 全体
    - メソッドの戻り値を使用していない警告をサプレス
    - Javadocの修正
    - deprecatedなメソッドの置換（assertThat()）

- src/main/java/nablarch/fw/web/HttpCookie.java
    - [リフレクション対象のメソッドに解決できない警告をサプレス](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-440c7e5fe5d79388081a7519bf6e6807bb608126310d78fd6e509bf3fd05d0a7R45)
        - 複数あり

- src/main/java/nablarch/fw/web/HttpResponse.java
    - [ほかで変更されていないフィールドをfinalに変更](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR853)
        - [併せてnullチェックが不要となったので削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR356)
    - [deprecatedなメソッドが使用されている警告をサプレス](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR689)
        - getCookie()、setCookie()
    - [line.length() == 0 をline.isEmpty()に置換](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR1003)
    - [Integer.valueOf()をInteger.parseInt()に置換](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR1144)
    - [不要なprivateを削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR208)
    - [不要なstaticを削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR75)
    - [正規表現のパターンの警告（`$`のあとにパターンが続く）をサプレス](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR60)
    - [不要なString.valueOf()を削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR415)
    - [不要なtoString()を削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR986)
    - [ループ内の文字列追加を、+=からStringBuilderに変更](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR1012)
    - [不要な初期化を削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-789804807967c142352e8c18bc74ae82ce73b6e07fcaba17212a13cb113c3d8eR1074)

- src/test/java/nablarch/fw/web/HttpCookieTest.java
    - [deprecatedなメソッドの警告をサプレス（ExpectedException.none()）](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-5859ed808ed2ef0b5e2dba9fc76c820120e02cd934509c5ff604e31a04ec99eaR33)
    - [必ずnullになるステートメントの警告をサプレス](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-5859ed808ed2ef0b5e2dba9fc76c820120e02cd934509c5ff604e31a04ec99eaR275)
    - [リフレクション対象のメソッドに解決できない警告をサプレス](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-5859ed808ed2ef0b5e2dba9fc76c820120e02cd934509c5ff604e31a04ec99eaR300)

- src/test/java/nablarch/fw/web/HttpResponseTest.java
    - [Javadocコメントで入力値を表現している箇所の警告をサプレス](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-33d0e5e0ae964b927083fd71d428003f332fb5864e1b7db62f631ac51ce83823R34)
    - [テストコードに誤りがあったので修正](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-33d0e5e0ae964b927083fd71d428003f332fb5864e1b7db62f631ac51ce83823R149)
        - インスペクションでcookie2が使用されていない警告が出力されたことより。明らかなテストコード誤りであること、プロダクションコードに影響を与えるものではないことから、本対応で修正しました。
    - [deprecatedなメソッドの使用の警告をサプレス](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-33d0e5e0ae964b927083fd71d428003f332fb5864e1b7db62f631ac51ce83823R153)
        - setCookie()、getCookie()の使用。使用箇所は複数あり

- src/test/java/nablarch/fw/web/servlet/NablarchServletContextListenerTest.java
    - [キャストを Book.class.cast()の形式から(Book)の形式に置換](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-d151e6ecbdfd75e4ea7c45f09cc51890ea4cdc9e50d33eef61781a67e04ace5cR67)
        - 複数あり
    - [不要なセミコロンを削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-d151e6ecbdfd75e4ea7c45f09cc51890ea4cdc9e50d33eef61781a67e04ace5cR287)

- src/test/resources/nablarch/fw/web/servlet/nablarch-servlet-context-restrequesttest-test.xml
    - [使用されていない名前空間を削除](https://github.com/nablarch/nablarch-fw-web/pull/124/files#diff-b2cf1e6ea0a635c636fef5cc4f0412dfe56f238a4e2c1b5591f5355b06687bdfR2)
        - テストコードであることも踏まえ、削除で問題ないと判断しました。