### PR TITLE
Jetty 12.0.3 へのバージョンアップによりワークアラウンド除去

### DIFF
--- a/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/HttpResponseHandler.java
@@ -471,10 +471,6 @@ public class HttpResponseHandler implements Handler<HttpRequest, HttpResponse> {
             if ("Content-Length".equals(key)) {
                 continue;
             }
-            // Jetty 12でContent-Typeを複数回設定するとCharacterEncodingがリセットされてしまうため回避
-            if ("Content-Type".equals(key)) {
-                continue;
-            }
             if ("Content-Disposition".equals(key)) {
                 val = replaceContentDisposition(val, ctx.getServletRequest());
             }


### PR DESCRIPTION
バージョンアップにより Jetty 12.0.0 で発生していた文字化けが解消されたため、ワークアラウンドを戻しました。
