### PR TITLE
言語別リソースチェック対象かをクエリパラメータ付でも正しく判定されるよう修正

### DIFF
--- a/src/main/java/nablarch/fw/web/i18n/ResourcePathRule.java
+++ b/src/main/java/nablarch/fw/web/i18n/ResourcePathRule.java
@@ -67,7 +67,7 @@ public abstract class ResourcePathRule {
         String pathForLanguage = createPathForLanguage(pathFromContextRoot, locale.getLanguage());
 
         // 言語対応のリソースパスが指すファイルが存在しない場合。
-        if (!existsResource(pathForLanguage, request)) {
+        if (!existsResource(removeQueryParameter(pathForLanguage), request)) {
             return path;
         }
 

--- a/src/main/java/nablarch/fw/web/i18n/ResourcePathRule.java
+++ b/src/main/java/nablarch/fw/web/i18n/ResourcePathRule.java
@@ -56,6 +56,8 @@ public abstract class ResourcePathRule {
         }
 
         // リソースパスの判定にクエリパラメータは不要なため除去
+        // （クエリパラメータがあると正しい存在チェックができず、クエリパラメータに含まれる
+        //   文字列が原因でエラーになる可能性もあるため、クエリパラメータは除去する）
         String basePath = removeQueryParameter(path);
 
         int extensionIndex = basePath.lastIndexOf('.');
@@ -70,9 +72,7 @@ public abstract class ResourcePathRule {
         String pathForLanguage = createPathForLanguage(pathFromContextRoot, locale.getLanguage());
 
         // 言語対応のリソースパスが指すファイルが存在しない場合。
-        // （クエリパラメータがあると正しい存在チェックができず、クエリパラメータに含まれる
-        //   文字列が原因でエラーになる可能性もあるため、クエリパラメータは除去する）
-        if (!existsResource(removeQueryParameter(pathForLanguage), request)) {
+        if (!existsResource(pathForLanguage, request)) {
             return path;
         }
 

--- a/src/main/java/nablarch/fw/web/i18n/ResourcePathRule.java
+++ b/src/main/java/nablarch/fw/web/i18n/ResourcePathRule.java
@@ -55,7 +55,7 @@ public abstract class ResourcePathRule {
             return path;
         }
 
-        int extensionIndex = path.lastIndexOf('.');
+        int extensionIndex = removeQueryParameter(path).lastIndexOf('.');
         if (extensionIndex == -1) { // 拡張子を含まない場合。
             return path;
         }
@@ -122,4 +122,18 @@ public abstract class ResourcePathRule {
      * @return 言語対応のリソースパス
      */
     protected abstract String createPathForLanguage(String pathFromContextRoot, String language);
+
+    /**
+     * リソースパスからクエリパラメータ部分を除去する。
+     *
+     * @param path リソースパス
+     * @return クエリパラメータ部分を除去したリソースパス
+     */
+    private String removeQueryParameter(String path) {
+        int queryParameterIndex = path.indexOf('?');
+        if (queryParameterIndex == -1) {
+            return path;
+        }
+        return path.substring(0, queryParameterIndex);
+    }
 }

--- a/src/test/java/nablarch/fw/web/i18n/ResourcePathRuleTest.java
+++ b/src/test/java/nablarch/fw/web/i18n/ResourcePathRuleTest.java
@@ -186,10 +186,20 @@ public class ResourcePathRuleTest {
         ThreadContext.setLanguage(new Locale("ja"));
         assertThat(rule.getPathForLanguage(path, request), is("i18n/test"));
 
+        // 拡張子を含まない場合。（クエリパラメータ付き）
+        path = "i18n/test?key=value";
+        ThreadContext.setLanguage(new Locale("ja"));
+        assertThat(rule.getPathForLanguage(path, request), is("i18n/test?key=value"));
+
         // 言語対応のリソースファイルが存在する場合。(相対パス)
         path = "i18n/test.jsp";
         ThreadContext.setLanguage(new Locale("ja"));
         assertThat(rule.getPathForLanguage(path, request), is("i18n/test.jsp_ja"));
+
+        // 言語対応のリソースファイルが存在する場合。(相対パス)（クエリパラメータ付き）
+        path = "i18n/test.jsp?key=value";
+        ThreadContext.setLanguage(new Locale("ja"));
+        assertThat(rule.getPathForLanguage(path, request), is("i18n/test.jsp_ja?key=value"));
 
         // 言語対応のリソースファイルが存在しない場合。(相対パス)
         path = "i18n/test.jsp";


### PR DESCRIPTION
### 課題

言語別リソースチェック対象かは拡張子があるリソースパスだけであるが、リソースパスに拡張子は無いがクエリパラメータがある場合は正しく判定されず、チェック対象となっていた。
チェック対象となっても言語別リソースは見つからないため動作に支障は無かったが、アプリケーションサーバによってはチェック時に実行環境で使用できない文字が含まれてエラーとなってしまう場合があった。

### 対応方法

リソースパスにクエリパラメータがある場合は除去し、言語別リソースチェック対象外となるようにする。

### 補足

修正前の誤った判定でも結果としてリソースパスが変わることはなかったため、この修正前後でアプリケーションの動作は変わらない。