### PR TITLE
test: Java21でテストすると内部クラスの表現が変わっているため、エラーメッセージの検証方法について修正

### DIFF
--- a/src/test/java/nablarch/fw/web/InterceptorTest.java
+++ b/src/test/java/nablarch/fw/web/InterceptorTest.java
@@ -1,7 +1,9 @@
 package nablarch.fw.web;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.lang.annotation.Annotation;
@@ -539,8 +541,12 @@ public class InterceptorTest {
             Interceptor.Factory.wrap(handler);
             fail();
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("interceptor is undefined in the interceptorsOrder."
-                    + " undefined interceptors=[@nablarch.fw.web.InterceptorTest$HyphenDecorator()]"));
+            assertThat(e.getMessage(), startsWith("interceptor is undefined in the interceptorsOrder."
+                + " undefined interceptors="));
+
+            String interceptorName = e.getMessage().replace("interceptor is undefined in the interceptorsOrder."
+                + " undefined interceptors=", "");
+            assertThat(interceptorName, containsString(HyphenDecorator.class.getSimpleName()));
         }
     }
 

--- a/src/test/java/nablarch/fw/web/InterceptorTest.java
+++ b/src/test/java/nablarch/fw/web/InterceptorTest.java
@@ -541,6 +541,7 @@ public class InterceptorTest {
             Interceptor.Factory.wrap(handler);
             fail();
         } catch (IllegalArgumentException e) {
+            // Java 21での検証時に内部クラスのオブジェクト文字列表現が $内部クラス から .内部クラス（&HyphenDecoratorから.HyphenDecorator）に変わっていたため、バージョンに影響を受けないようにクラス名だけで検証する。
             assertThat(e.getMessage(), startsWith("interceptor is undefined in the interceptorsOrder."
                 + " undefined interceptors="));
 


### PR DESCRIPTION
Java21でテストを実行すると以下のエラーが発生しました。
> Expected: is "interceptor is undefined in the interceptorsOrder. undefined interceptors=[@nablarch.fw.web.InterceptorTest$HyphenDecorator()]"
     but: was "interceptor is undefined in the interceptorsOrder. undefined interceptors=[@nablarch.fw.web.InterceptorTest.HyphenDecorator()]"
	at nablarch.fw.web.InterceptorTest.testInterceptorOrdersUnknownInterceptor(InterceptorTest.java:542)

おそらく内部クラスの表現がProxyクラスでの表現が変更されているので、エラーメッセージの検証方法を修正しました。