### PR TITLE
JakartaEE10対応で、JavaEE由来の表現を修正

### DIFF
--- a/src/main/java/nablarch/fw/web/servlet/WebFrontController.java
+++ b/src/main/java/nablarch/fw/web/servlet/WebFrontController.java
@@ -39,10 +39,10 @@ import nablarch.fw.web.HttpRequest;
  * デプロイメントディスクリプタの記述例
  * -------------------------------------
  * &lt;?xml version="1.0" encoding="UTF-8"?>
- * &lt;web-app xmlns="http://java.sun.com/xml/ns/javaee"
+ * &lt;web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
  *          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
- *          version="2.5">
+ *          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+ *          version="6.0">
  *   &lt;display-name>w8&lt;/display-name>
  *   &lt;description>
  *     The default application-context for w8.http-based applications.

--- a/src/test/resources/nablarch/fw/web/sample/app/jsp/jstl_test.jsp
+++ b/src/test/resources/nablarch/fw/web/sample/app/jsp/jstl_test.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jsch/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html>
   <head>
     <title>Greeting Service</title>


### PR DESCRIPTION
以下の修正を実施

- タグファイル中のuriをJakarta Standard Tag Libraryのものに変更 (e2344ca2d088e32147fe85f2df78b87f51508884)
  - 対応内容は https://github.com/nablarch/nablarch-testing-jetty12/pull/7 と同様
- Javadoc中のデプロイメント記述子の記載をJakarta Servlet 6.0向けのものに修正
  - 対応内容は https://github.com/nablarch/nablarch-testing/pull/71 と同様