### PR TITLE
CSPに対応できるようにするため、nonceを生成する機能を追加する

### DIFF
--- a/src/main/java/nablarch/fw/web/handler/SecureHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/SecureHandler.java
@@ -65,7 +65,7 @@ public class SecureHandler implements HttpRequestHandler {
     }
 
     /**
-     * nonceを自動生成するかどうかの設定
+     * nonceを自動生成するかどうかの設定。
      * デフォルト値はfalseである。
      *
      * @param generateCspNonce nonceを自動生成するかどうか

--- a/src/main/java/nablarch/fw/web/handler/SecureHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/SecureHandler.java
@@ -28,6 +28,10 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
  * @author Hisaaki Shioiri
  */
 public class SecureHandler implements HttpRequestHandler {
+
+    /**
+     * CSP nonce生成の要求を表す値をリクエストスコープに設定する際に使用するキー
+     */
     public static String CSP_NONCE_KEY = ExecutionContext.FW_PREFIX + "csp_nonce";
 
     /**
@@ -41,14 +45,32 @@ public class SecureHandler implements HttpRequestHandler {
                     new ReferrerPolicyHeader(),
                     new CacheControlHeader());
 
+    /**
+     * nonceを自動生成するかどうか
+     */
     private boolean generateCspNonce = false;
 
+    /**
+     * nonceの生成用の 乱数ジェネレータ
+     */
     private SecureRandom random = new SecureRandom();
 
+    /**
+     * nonceを自動生成するかどうか。
+     *
+     * @return trueの場合は、自動生成する
+     */
     public boolean isGenerateCspNonce() {
         return generateCspNonce;
     }
 
+    /**
+     * nonceを自動生成するかどうかの設定
+     * デフォルト値はfalseである。
+     *
+     * @param generateCspNonce nonceを自動生成するかどうか
+     *
+     */
     public void setGenerateCspNonce(boolean generateCspNonce) {
         this.generateCspNonce = generateCspNonce;
     }

--- a/src/main/java/nablarch/fw/web/handler/SecureHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/SecureHandler.java
@@ -75,10 +75,6 @@ public class SecureHandler implements HttpRequestHandler {
         this.generateCspNonce = generateCspNonce;
     }
 
-    public List<? extends SecureResponseHeader> getSecureResponseHeaderList() {
-        return secureResponseHeaderList;
-    }
-
     @Override
     public HttpResponse handle(final HttpRequest request, final ExecutionContext context) {
         if (generateCspNonce) {

--- a/src/main/java/nablarch/fw/web/handler/SecureHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/SecureHandler.java
@@ -1,27 +1,38 @@
 package nablarch.fw.web.handler;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import nablarch.core.util.Base64Util;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpRequestHandler;
 import nablarch.fw.web.HttpResponse;
-import nablarch.fw.web.handler.secure.*;
+import nablarch.fw.web.handler.secure.CacheControlHeader;
+import nablarch.fw.web.handler.secure.ContentSecurityPolicyHeader;
+import nablarch.fw.web.handler.secure.ContentTypeOptionsHeader;
+import nablarch.fw.web.handler.secure.FrameOptionsHeader;
+import nablarch.fw.web.handler.secure.ReferrerPolicyHeader;
+import nablarch.fw.web.handler.secure.SecureResponseHeader;
+import nablarch.fw.web.handler.secure.XssProtectionHeader;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
  * セキュリティ関連のレスポンスヘッダを設定するハンドラ。
- *
+ * <p>
  * レスポンスヘッダに設定する値は、{@link #setSecureResponseHeaderList(List)}に設定された、値から取得する。
  * 特定条件の場合に出力を抑制する場合は、{@link SecureResponseHeader#isOutput(HttpResponse, ServletExecutionContext)}で、{@code false}を返すこと。
  *
  * @author Hisaaki Shioiri
  */
 public class SecureHandler implements HttpRequestHandler {
+    public static String CSP_NONCE_KEY = ExecutionContext.FW_PREFIX + "csp_nonce";
 
-    /** セキュリティ関連のレスポンスヘッダを構築するオブジェクト */
+    /**
+     * セキュリティ関連のレスポンスヘッダを構築するオブジェクト
+     */
     private List<? extends SecureResponseHeader> secureResponseHeaderList =
             Arrays.asList(
                     new FrameOptionsHeader(),
@@ -30,14 +41,47 @@ public class SecureHandler implements HttpRequestHandler {
                     new ReferrerPolicyHeader(),
                     new CacheControlHeader());
 
+    private boolean generateCspNonce = false;
+
+    private SecureRandom random = new SecureRandom();
+
+    public boolean isGenerateCspNonce() {
+        return generateCspNonce;
+    }
+
+    public void setGenerateCspNonce(boolean generateCspNonce) {
+        this.generateCspNonce = generateCspNonce;
+    }
+
+    public List<? extends SecureResponseHeader> getSecureResponseHeaderList() {
+        return secureResponseHeaderList;
+    }
+
     @Override
     public HttpResponse handle(final HttpRequest request, final ExecutionContext context) {
+        if (generateCspNonce) {
+            // nonceは128ビット以上の暗号的乱数生成器を使用して、リクエストの都度生成することが推奨されている
+            // https://www.w3.org/TR/CSP3/#security-nonces
+            byte[] bytes = new byte[16];
+            random.nextBytes(bytes);
+            String nonce = Base64Util.encode(bytes);
+
+            context.setRequestScopedVar(CSP_NONCE_KEY, nonce);
+        }
+
         final HttpResponse response = context.handleNext(request);
 
         final ServletExecutionContext servletExecutionContext = (ServletExecutionContext) context;
         for (final SecureResponseHeader responseHeader : secureResponseHeaderList) {
             if (responseHeader.isOutput(response, servletExecutionContext)) {
-                response.setHeader(responseHeader.getName(), responseHeader.getValue());
+                if (responseHeader instanceof ContentSecurityPolicyHeader) {
+                    response.setHeader(
+                            responseHeader.getName(),
+                            ((ContentSecurityPolicyHeader) responseHeader).getFormattedValue(servletExecutionContext)
+                    );
+                } else {
+                    response.setHeader(responseHeader.getName(), responseHeader.getValue());
+                }
             }
         }
         return response;
@@ -45,6 +89,7 @@ public class SecureHandler implements HttpRequestHandler {
 
     /**
      * セキュリティ関連のヘッダ情報を生成する{@link SecureResponseHeader}を設定する。
+     *
      * @param secureResponseHeaderList {@code SecureResponseHeader}のリスト
      */
     public void setSecureResponseHeaderList(

--- a/src/main/java/nablarch/fw/web/handler/SecureHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/SecureHandler.java
@@ -20,7 +20,7 @@ import nablarch.fw.web.handler.secure.XssProtectionHeader;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
- * セキュリティ関連のレスポンスヘッダを設定するハンドラ。
+ * Webアプリケーションのセキュリティに関する処理やヘッダ設定を行うハンドラ。
  * <p>
  * レスポンスヘッダに設定する値は、{@link #setSecureResponseHeaderList(List)}に設定された、値から取得する。
  * 特定条件の場合に出力を抑制する場合は、{@link SecureResponseHeader#isOutput(HttpResponse, ServletExecutionContext)}で、{@code false}を返すこと。
@@ -51,7 +51,7 @@ public class SecureHandler implements HttpRequestHandler {
     private boolean generateCspNonce = false;
 
     /**
-     * nonceの生成用の 乱数ジェネレータ
+     * nonceの生成用の乱数ジェネレータ
      */
     private final SecureRandom random = new SecureRandom();
 

--- a/src/main/java/nablarch/fw/web/handler/SecureHandler.java
+++ b/src/main/java/nablarch/fw/web/handler/SecureHandler.java
@@ -53,7 +53,7 @@ public class SecureHandler implements HttpRequestHandler {
     /**
      * nonceの生成用の 乱数ジェネレータ
      */
-    private SecureRandom random = new SecureRandom();
+    private final SecureRandom random = new SecureRandom();
 
     /**
      * nonceを自動生成するかどうか。

--- a/src/main/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeader.java
+++ b/src/main/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeader.java
@@ -7,7 +7,7 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
  * Content-Security-Policyレスポンスヘッダを設定するクラス。
- *
+ * <p>
  * {@link #setReportOnly(boolean)} に{@code true}を設定した場合は、
  * Content-Security-Policy-Report-Onlyレスポンスヘッダを出力する。
  * 
@@ -21,7 +21,7 @@ public class ContentSecurityPolicyHeader implements SecureResponseHeader {
     /** report-onlyモード */
     private boolean reportOnly;
     /** プレースホルダー文字列 */
-    private String cspNonceSourcePlaceHolder = "$cspNonceSource$";
+    private final String cspNonceSourcePlaceHolder = "$cspNonceSource$";
 
     /**
      * Content-Security-Policyを設定する。

--- a/src/main/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeader.java
+++ b/src/main/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeader.java
@@ -20,7 +20,7 @@ public class ContentSecurityPolicyHeader implements SecureResponseHeader {
     private String policy;
     /** report-onlyモード */
     private boolean reportOnly;
-
+    /** プレースホルダー文字列 */
     private String cspNonceSourcePlaceHolder = "$cspNonceSource$";
 
     /**
@@ -60,6 +60,13 @@ public class ContentSecurityPolicyHeader implements SecureResponseHeader {
         return policy;
     }
 
+    /**
+     * セキュアハンドラでnonceが自動生成されている場合は、プレースホルダーをnonceに置換する。
+     * 自動生成されていない場合は、プレースホルダーをそのまま返す。
+     *
+     * @param context 実行コンテキスト
+     * @return レスポンスヘッダの値
+     */
     public String getFormattedValue(ServletExecutionContext context) {
         String rawPolicy = getValue();
 

--- a/src/main/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeader.java
+++ b/src/main/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeader.java
@@ -1,6 +1,8 @@
 package nablarch.fw.web.handler.secure;
 
+import nablarch.core.util.StringUtil;
 import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.handler.SecureHandler;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 
 /**
@@ -18,6 +20,8 @@ public class ContentSecurityPolicyHeader implements SecureResponseHeader {
     private String policy;
     /** report-onlyモード */
     private boolean reportOnly;
+
+    private String cspNonceSourcePlaceHolder = "$cspNonceSource$";
 
     /**
      * Content-Security-Policyを設定する。
@@ -52,7 +56,20 @@ public class ContentSecurityPolicyHeader implements SecureResponseHeader {
         } else if (policy.isEmpty()) {
             throw new IllegalStateException("invalid Content-Security-Policy. policy is empty");
         }
+
         return policy;
+    }
+
+    public String getFormattedValue(ServletExecutionContext context) {
+        String rawPolicy = getValue();
+
+        String nonce = context.getRequestScopedVar(SecureHandler.CSP_NONCE_KEY);
+
+        if (StringUtil.isNullOrEmpty(nonce)) {
+            return rawPolicy;
+        }
+
+        return rawPolicy.replace(cspNonceSourcePlaceHolder, "nonce-" + nonce);
     }
 
     /**

--- a/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
@@ -2,7 +2,7 @@ package nablarch.fw.web.handler;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -13,11 +13,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import mockit.Verifications;
 import nablarch.core.util.Base64Util;
-import nablarch.fw.web.MockHttpRequest;
 import nablarch.fw.web.handler.secure.ContentSecurityPolicyHeader;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.collection.IsMapContaining;
 
@@ -59,7 +57,7 @@ public class SecureHandlerTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private Handler<HttpRequest, HttpResponse> handler = new Handler<HttpRequest, HttpResponse>() {
+    private final Handler<HttpRequest, HttpResponse> handler = new Handler<HttpRequest, HttpResponse>() {
         @Override
         public HttpResponse handle(final HttpRequest request, final ExecutionContext context) {
             return new HttpResponse(200);

--- a/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
@@ -102,7 +102,7 @@ public class SecureHandlerTest {
     }
 
     /**
-     * 出力対象外の場合、そのヘッダは出力されないこと
+     * 出力対象外の場合、そのヘッダは出力されないこと。
      */
     @Test
     public void withoutFrameOptions() {
@@ -120,7 +120,8 @@ public class SecureHandlerTest {
     }
 
     /**
-     * generateCspNonceをtrueに設定した場合、nonceが生成されContent-Security-Policyヘッダーに出力されること
+     * generateCspNonceをtrueにしている場合、リクエストスコープに生成されたnonceが保存されること。
+     * またContentSecurityPolicyHeaderを設定している場合は、プレースホルダーが生成されたnonceで置換されること。
      */
     @Test
     public void enableGenerateCspNonce() {
@@ -163,7 +164,7 @@ public class SecureHandlerTest {
     }
 
     /**
-     * デフォルト設定の場合、nonceが生成されないこと
+     * デフォルト設定の場合、nonceが生成されないこと。
      */
     @Test
     public void disableGenerateCspNonce(){
@@ -181,5 +182,10 @@ public class SecureHandlerTest {
                 IsMapContaining.hasEntry("X-XSS-Protection", "1; mode=block"),
                 IsMapContaining.hasEntry("Content-Security-Policy", "script-src 'self' '$cspNonceSource$'; style-src '$cspNonceSource$'")
         ));
+
+        new Verifications() {{
+            mockServletRequest.setAttribute(SecureHandler.CSP_NONCE_KEY, any);
+            times = 0;
+        }};
     }
 }

--- a/src/test/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeaderTest.java
+++ b/src/test/java/nablarch/fw/web/handler/secure/ContentSecurityPolicyHeaderTest.java
@@ -1,7 +1,7 @@
 package nablarch.fw.web.handler.secure;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import nablarch.fw.web.handler.SecureHandler;
 import nablarch.fw.web.servlet.MockServletContext;


### PR DESCRIPTION
CSPに対応できるようにするため、セキュアハンドラにnonceを生成する機能を追加しました。

合わせてinspection対応も行いました。