### PR TITLE
SecureHandlerTestのmatchesSafelyが常にtrueで、describeToで設定したエラーの際のメッセージが呼ばれないようになっていたため修正

### DIFF
--- a/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
+++ b/src/test/java/nablarch/fw/web/handler/SecureHandlerTest.java
@@ -149,9 +149,7 @@ public class SecureHandlerTest {
                 @Override
                 protected boolean matchesSafely(String item) {
                     byte[] binary = Base64Util.decode(item);
-                    assertThat(binary.length, is(16));
-
-                    return true;
+                    return binary.length == 16;
                 }
 
                 @Override


### PR DESCRIPTION
SecureHandlerTestの`matchesSafely()`が常に`true`で、`describeTo()`で設定したエラーの際のメッセージが呼ばれないようになっていたため修正しました。
`describeTo()`は`matchesSafely()`がfalseの際に呼ばれます。