### PR TITLE
org.eclipse.jdt.core.compiler:ecjへの依存の削除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,19 +103,6 @@
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jdt.core.compiler</groupId>
-          <artifactId>ecj</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jdt.core.compiler</groupId>
-      <artifactId>ecj</artifactId>
-      <version>4.6.1</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-testing/pull/73 でnablarch-testingから
`org.eclipse.jdt.core.compiler:ecj`を削除したため、こちらのexclusionも削除しました。

また、jetty12がグループIDが変更された新しいバージョンの`org.eclipse.jdt:ecj:3.33.0`を引っ張ってきているので、`org.eclipse.jdt.core.compiler:ecj`は使用されていないため依存関係ごと削除しました。