### PR TITLE
BeanValidationStrategyをカスタマイズできるように修正

### DIFF
--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -59,11 +59,11 @@ public class BeanValidationStrategy implements ValidationStrategy {
     }
 
     /**
-     * リクエスト内容をバリデーションするために、{@link InjectForm}のform属性で指定された型のオブジェクトを生成して返す。
+     * {@link InjectForm}のform属性で指定された型のフォームを生成する。
      *
      * @param request リクエスト
      * @param annotation InjectFormアノテーション
-     * @return プロパティに値が登録されたフォーム
+     * @return リクエストパラメータが登録されたフォーム
      */
     protected Serializable createForm(HttpRequest request, InjectForm annotation) {
         Map<String, String[]> rawRequestParamMap = request.getParamMap();

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -59,13 +59,13 @@ public class BeanValidationStrategy implements ValidationStrategy {
     }
 
     /**
-     * リクエストパラメータからBeanオブジェクトを生成する。
+     * リクエスト内容をバリデーションするために、{@link InjectForm}のform属性で指定された型のオブジェクトを生成して返す。
      *
-     * @param request パラメータを含むHTTPリクエスト
-     * @param annotation {@code InjectForm}アノテーション
-     * @return プロパティに値が登録されたBeanオブジェクト
+     * @param request リクエスト
+     * @param annotation InjectFormアノテーション
+     * @return プロパティに値が登録されたフォーム
      */
-    public Serializable createBean(HttpRequest request, InjectForm annotation) {
+    public Serializable createForm(HttpRequest request, InjectForm annotation) {
         Map<String, String[]> rawRequestParamMap = request.getParamMap();
         Map<String, String[]> requestParamMap = getMapWithConvertedKey(annotation.prefix(), rawRequestParamMap);
 
@@ -77,7 +77,7 @@ public class BeanValidationStrategy implements ValidationStrategy {
     public Serializable validate(HttpRequest request, InjectForm annotation, boolean notUse,
             ServletExecutionContext context) {
 
-        Serializable bean = createBean(request, annotation);
+        Serializable bean = createForm(request, annotation);
         Validator validator = ValidatorUtil.getValidator();
         Set<ConstraintViolation<Serializable>> results = validator.validate(bean, annotation.validationGroup());
         if (!results.isEmpty()) {

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -65,30 +65,30 @@ public class BeanValidationStrategy implements ValidationStrategy {
      * @param annotation InjectFormアノテーション
      * @return プロパティに値が登録されたフォーム
      */
-    public Serializable createForm(HttpRequest request, InjectForm annotation) {
+    protected Serializable createForm(HttpRequest request, InjectForm annotation) {
         Map<String, String[]> rawRequestParamMap = request.getParamMap();
         Map<String, String[]> requestParamMap = getMapWithConvertedKey(annotation.prefix(), rawRequestParamMap);
 
-        Serializable bean = formFactory.create(annotation.form());
-        BeanUtil.copy(annotation.form(), bean, requestParamMap, CopyOptions.empty());
-        return bean;
+        Serializable form = formFactory.create(annotation.form());
+        BeanUtil.copy(annotation.form(), form, requestParamMap, CopyOptions.empty());
+        return form;
     }
 
     public Serializable validate(HttpRequest request, InjectForm annotation, boolean notUse,
             ServletExecutionContext context) {
 
-        Serializable bean = createForm(request, annotation);
+        Serializable form = createForm(request, annotation);
         Validator validator = ValidatorUtil.getValidator();
-        Set<ConstraintViolation<Serializable>> results = validator.validate(bean, annotation.validationGroup());
+        Set<ConstraintViolation<Serializable>> results = validator.validate(form, annotation.validationGroup());
         if (!results.isEmpty()) {
             if (copyBeanToRequestScopeOnError) {
                 // エラーのとき、リクエストスコープにbeanを設定する
-                context.setRequestScopedVar(annotation.name(), bean);
+                context.setRequestScopedVar(annotation.name(), form);
             }
             List<Message> messages = new ConstraintViolationConverterFactory().create(annotation.prefix()).convert(results);
             throw new ApplicationException(sortMessages(messages, context, annotation));
         }
-        return bean;
+        return form;
     }
 
     /**

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -58,14 +58,26 @@ public class BeanValidationStrategy implements ValidationStrategy {
     public BeanValidationStrategy() {   // NOP
     }
 
-    public Serializable validate(HttpRequest request, InjectForm annotation, boolean notUse,
-            ServletExecutionContext context) {
-
+    /**
+     * リクエストパラメータからBeanオブジェクトを生成する。
+     *
+     * @param request パラメータを含むHTTPリクエスト
+     * @param annotation {@code InjectForm}アノテーション
+     * @return プロパティに値が登録されたBeanオブジェクト
+     */
+    public Serializable createBean(HttpRequest request, InjectForm annotation) {
         Map<String, String[]> rawRequestParamMap = request.getParamMap();
         Map<String, String[]> requestParamMap = getMapWithConvertedKey(annotation.prefix(), rawRequestParamMap);
 
         Serializable bean = formFactory.create(annotation.form());
         BeanUtil.copy(annotation.form(), bean, requestParamMap, CopyOptions.empty());
+        return bean;
+    }
+
+    public Serializable validate(HttpRequest request, InjectForm annotation, boolean notUse,
+            ServletExecutionContext context) {
+
+        Serializable bean = createBean(request, annotation);
         Validator validator = ValidatorUtil.getValidator();
         Set<ConstraintViolation<Serializable>> results = validator.validate(bean, annotation.validationGroup());
         if (!results.isEmpty()) {

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -91,7 +91,7 @@ public class BeanValidationStrategy implements ValidationStrategy {
      * @return ソートしたメッセージリスト
      */
     @Published(tag = "architect")
-    protected static List<Message> sortMessages(
+    protected List<Message> sortMessages(
             final List<Message> messages, final ServletExecutionContext context, final InjectForm injectForm) {
         final ServletRequest request = context.getServletRequest()
                                               .getRequest();

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -40,6 +40,7 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
  *
  * @author sumida
  */
+@Published(tag = "architect")
 public class BeanValidationStrategy implements ValidationStrategy {
 
     /** バリデーションエラー時にBeanをリクエストスコープにコピーするかどうか */
@@ -54,7 +55,6 @@ public class BeanValidationStrategy implements ValidationStrategy {
     /**
      * {@code BeanValidationStrategy}を生成する。
      */
-    @Published(tag = "architect")
     public BeanValidationStrategy() {   // NOP
     }
 
@@ -90,7 +90,6 @@ public class BeanValidationStrategy implements ValidationStrategy {
      * @param injectForm {@code InjectForm}アノテーション
      * @return ソートしたメッセージリスト
      */
-    @Published(tag = "architect")
     protected List<Message> sortMessages(
             final List<Message> messages, final ServletExecutionContext context, final InjectForm injectForm) {
         final ServletRequest request = context.getServletRequest()


### PR DESCRIPTION
`BeanValidationStrategy`に関して以下の修正を行いました。

- [解説書内](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/validation/bean_validation.html#bean-validation-web-application)では「プロジェクトでソート順を変更したい場合は、BeanValidationStrategyを継承し対応すること」と案内されているのにも関わらず、`sortMessages`メソッドはstaticメソッドとなっていたためstaticを削除しました。
- バリデーション処理をカスタマイズできるようにクラス全体を公開API（アーキテクト向け）としました。
- バリデーション処理のうち、基本的にはリクエストパラメータから Bean オブジェクトを生成するロジックのみをカスタマイズするかと思うので、該当部分のロジック部分をメソッドで切り出し、カスタマイズしやすくしました。