### PR TITLE
IntelliJのInspectionの警告対応

### DIFF
--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -106,7 +106,6 @@ public class BeanValidationStrategy implements ValidationStrategy {
         final ServletRequest request = context.getServletRequest()
                                               .getRequest();
 
-        @SuppressWarnings("unchecked")
         final List<String> parameterNames = Collections.list(request.getParameterNames());
 
         final List<Message> sortedMessage = new ArrayList<>(messages);

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -3,7 +3,6 @@ package nablarch.common.web.validator;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,7 +109,7 @@ public class BeanValidationStrategy implements ValidationStrategy {
         @SuppressWarnings("unchecked")
         final List<String> parameterNames = Collections.list(request.getParameterNames());
 
-        final List<Message> sortedMessage = new ArrayList<Message>(messages);
+        final List<Message> sortedMessage = new ArrayList<>(messages);
         Collections.sort(sortedMessage, (m1, m2) -> {
             final int index1 = getParameterIndex(parameterNames, m1);
             final int index2 = getParameterIndex(parameterNames, m2);
@@ -155,12 +154,12 @@ public class BeanValidationStrategy implements ValidationStrategy {
     private Map<String, String[]> getMapWithConvertedKey(String prefix, Map<String, String[]> reqParamMap) {
         if (StringUtil.isNullOrEmpty(prefix)) {
             // プレフィックスが指定されない場合、全てが対象とする
-            return new HashMap<String, String[]>(reqParamMap);
+            return new HashMap<>(reqParamMap);
         }
 
         final String prefixName = prefix + '.';
         final int prefixLength = prefixName.length();
-        Map<String, String[]> convertedMap = new HashMap<String, String[]>();
+        Map<String, String[]> convertedMap = new HashMap<>();
         for (Map.Entry<String, String[]> entry : reqParamMap.entrySet()) {
             final String key = entry.getKey();
             final String[] value = entry.getValue();

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -110,7 +110,7 @@ public class BeanValidationStrategy implements ValidationStrategy {
         final List<String> parameterNames = Collections.list(request.getParameterNames());
 
         final List<Message> sortedMessage = new ArrayList<>(messages);
-        Collections.sort(sortedMessage, (m1, m2) -> {
+        sortedMessage.sort((m1, m2) -> {
             final int index1 = getParameterIndex(parameterNames, m1);
             final int index2 = getParameterIndex(parameterNames, m2);
 

--- a/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
+++ b/src/main/java/nablarch/common/web/validator/BeanValidationStrategy.java
@@ -111,22 +111,19 @@ public class BeanValidationStrategy implements ValidationStrategy {
         final List<String> parameterNames = Collections.list(request.getParameterNames());
 
         final List<Message> sortedMessage = new ArrayList<Message>(messages);
-        Collections.sort(sortedMessage, new Comparator<Message>() {
-            @Override
-            public int compare(final Message m1, final Message m2) {
-                final int index1 = getParameterIndex(parameterNames, m1);
-                final int index2 = getParameterIndex(parameterNames, m2);
-                
-                if (index1 < index2) {
-                    // m1のほうが小さい場合
-                    return -1;
-                } else if (index2 < index1) {
-                    // m2のほうが小さい場合
-                    return 1;
-                } else {
-                    // それ以外は同じと扱う
-                    return 0;
-                }
+        Collections.sort(sortedMessage, (m1, m2) -> {
+            final int index1 = getParameterIndex(parameterNames, m1);
+            final int index2 = getParameterIndex(parameterNames, m2);
+
+            if (index1 < index2) {
+                // m1のほうが小さい場合
+                return -1;
+            } else if (index2 < index1) {
+                // m2のほうが小さい場合
+                return 1;
+            } else {
+                // それ以外は同じと扱う
+                return 0;
             }
         });
         return sortedMessage;


### PR DESCRIPTION
`BeanValidationStrategy`に対して、Inspectionの警告対応を実施しました。
修正後、Junitテストが通ることは確認しています。
なお、下記の2件の警告は対応が不要だと考えたためそのままにしています。

- `compare()` メソッドを使用して数値を比較可能（116行目）
  - ソート順のカスタマイズが想定されているので、既存の実装の方がカスタマイズしやすいと判断したため。
- ` sortMessages(List<Message>, ServletExecutionContext, InjectForm)`メソッドでパラメーター 'injectForm' は使用されません（105行目）
  - ソート順のカスタマイズが想定されているので、InjectFormの情報を使う可能性があるため。